### PR TITLE
Revise reflashing info and add GPIO configuration

### DIFF
--- a/src/docs/devices/Mirabella-Genio-Wi-Fi-1.4m-Pixel-LED-Corner-Light/index.md
+++ b/src/docs/devices/Mirabella-Genio-Wi-Fi-1.4m-Pixel-LED-Corner-Light/index.md
@@ -19,9 +19,8 @@ individually addressable leds with a corner stand frame.
 They are sold at [Kmart NZ](https://www.kmart.co.nz/product/mirabella-genio-wi-fi-1.4m-pixel-led-corner-light-43205363/)
 and [Kmart AU](https://www.kmart.com.au/product/mirabella-genio-wi-fi-14m-pixel-led-corner-light-43205363/).
 
-Inside is a [T103_V1.0](https://docs.libretiny.eu/boards/t103-v1.0/) module based on the RTL8710BX MCU. I believe this
-is prossible to reflash using [LibreTiny](https://docs.libretiny.eu/docs/platform/realtek-ambz/) but I have not done so
-myself so do at your own risk. Please update this page if you are successful.
+Inside is a [T103_V1.0](https://docs.libretiny.eu/boards/t103-v1.0/) module based on the RTL8710BX MCU. This
+is prossible to reflash using [LibreTiny](https://docs.libretiny.eu/docs/platform/realtek-ambz/), but both FastLED and NeoPixelBus led drivers are unsupported on this platform so it's not possible to drive the LEDs.
 
 ![Mirabella Genio Wi-Fi 1.4m Pixel LED Corner Light Teardown][2]
 
@@ -39,8 +38,65 @@ myself so do at your own risk. Please update this page if you are successful.
 ```yaml
 # Config for Mirabella Genio Wi-Fi 1.4m Pixel LED Corner Light
 # https://devices.esphome.io/devices/Mirabella-Genio Wi-Fi-1.4m-Pixel-LED-Corner-Light/
+
 rtl87xx:
   board: t103-v1.0
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: PA12
+      mode: INPUT_PULLUP
+      inverted: true
+    name: "Power Button"
+    on_press:
+      - light.toggle: corner_light
+
+  - platform: gpio
+    pin:
+      number: PA05
+      mode: INPUT_PULLUP
+      inverted: true
+    name: "LED Button"
+    on_press:
+      - light.toggle: corner_light
+
+  - platform: gpio
+    pin:
+      number: PA00
+      mode: INPUT_PULLUP
+      inverted: true
+    name: "Sound Button"
+    on_press:
+      - switch.toggle: sound_reactive_mode
+
+switch:
+  - platform: template
+    name: "Sound Reactive Mode"
+    id: sound_reactive_mode
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_OFF
+
+sensor:
+  - platform: adc
+    pin: ADC2
+    name: "Microphone Raw"
+    id: mic_raw
+    update_interval: 50ms
+
+light:
+  - platform: fastled_clockless
+    id: corner_light
+    name: "Corner Light"
+    chipset: UCS1903
+    pin: PA23
+    rgb_order: BRG
+    num_leds: 28
+    restore_mode: RESTORE_DEFAULT_OFF
+    default_transition_length: 0s
+    effects:
+      - addressable_rainbow:
+      - pulse:
 ```
 
 [1]: /Mirabella-Genio-Wi-Fi-1.4m-Pixel-LED-Corner-Light-Packaging.png "Mirabella Genio Wi-Fi 1.4m Pixel LED Corner


### PR DESCRIPTION
Updated reflashing information and added GPIO configuration details for the Mirabella Genio Wi-Fi 1.4m Pixel LED Corner Light.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

I spent a couple days trying to get this light to work, and I'd at least like to share with the community the result I've achieved. All the GPIOs are there, but the led drivers can't drive the strip so for now there's no point flashing esphome to this device.

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
