### PR TITLE
Enable HA API for Petkit Fresh Element Solo Pet Feeder.

### DIFF
--- a/src/docs/devices/Petkit-Fresh-Element-Solo-Pet-Feeder/index.md
+++ b/src/docs/devices/Petkit-Fresh-Element-Solo-Pet-Feeder/index.md
@@ -120,6 +120,10 @@ logger:
 web_server:
   port: 80
 
+api:
+  encryption:
+    key: !secret encryption_key
+
 globals:
   - id: scoops_count
     type: int


### PR DESCRIPTION
This fixes an issue where homeassistant.event is not found at compile time.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

This fixes an issue where `homeassistant.event` is not found at compile time for Petkit Fresh Element Solo Pet Feeder.

`Unable to find action with the name 'homeassistant.event'.`

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
