### PR TITLE
Add wifi settings to petkit fresh element solo pet feeder.

### DIFF
--- a/src/docs/devices/Petkit-Fresh-Element-Solo-Pet-Feeder/index.md
+++ b/src/docs/devices/Petkit-Fresh-Element-Solo-Pet-Feeder/index.md
@@ -120,6 +120,10 @@ logger:
 web_server:
   port: 80
 
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
 globals:
   - id: scoops_count
     type: int


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Add wifi settings example to petkit fresh element solo pet feeder.

## Type of changes

- [ ] New device
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

- [x] There are no passwords or secrets references in any examples. 
      The only exceptions are `!secret wifi_ssid` and `!secret wifi_password`.
- [x] The `wifi` or `ethernet` block has no static / manual ip address specified.
- [x] The first configuration provided should be **hardware definitions only**.
      A more involved example can be provided in a separate configuration block.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
