### PR TITLE
Note that Athom Smart Plug US V3 is rebranded as IoTorero.

### DIFF
--- a/src/docs/devices/Athom-Smart-Plug-PG03V3-US16A/index.md
+++ b/src/docs/devices/Athom-Smart-Plug-PG03V3-US16A/index.md
@@ -11,6 +11,10 @@ made-for-esphome: true
 
 ![alt text](athom-plug-us-v3.webp "Athom Smart Plug US V3 - PG03V3-US16A")
 
+IoTorero is a rebranding of Athom; the
+[IoTorero Smart Plug US V3 (PG03V3-US16A)](../IoTorero-Smart-Plug-PG03V3-US16A)
+is otherwise identical.
+
 Maker: [https://www.athom.tech/](https://www.athom.tech/)
 Product page: [https://www.athom.tech/blank-1/esp32-c3-us-plug-for-esphome](https://www.athom.tech/blank-1/esp32-c3-us-plug-for-esphome)
 


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

Put a note in the Athom device that it is now called IoTorero and link to that.

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [x] Adding a new device adds a single device only — one device per pull request.
- [x] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [x] The first `file=` fence on the page references `config.yaml`.
- [x] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [x] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [x] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [x] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
