### PR TITLE
fix: update broken external links in device documentation

### DIFF
--- a/src/docs/devices/Athom-E27-15W-Bulb/index.md
+++ b/src/docs/devices/Athom-E27-15W-Bulb/index.md
@@ -6,7 +6,7 @@ standard: us
 board: esp8266
 ---
 
-Manufacturer: [Athom.tech](https://www.athom.tech/blank-1/15w-bulb-2-pack)
+Manufacturer: [Athom.tech](https://www.athom.tech/blank-1/15w-color-bulb-for-esphome)
 
 ## Flashing Procedure
 

--- a/src/docs/devices/Athom-E27-7W-Bulb/index.md
+++ b/src/docs/devices/Athom-E27-7W-Bulb/index.md
@@ -6,7 +6,7 @@ standard: us
 board: esp8266
 ---
 
-Manufacturer: [Athom.tech](https://www.athom.tech/blank-1/7w-2-pack)
+Manufacturer: [Athom.tech](https://www.athom.tech/blank-1/esphome-7w-color-bulb)
 
 ## Flashing Procedure
 

--- a/src/docs/devices/Solis-S3-WiFi-Stick/index.md
+++ b/src/docs/devices/Solis-S3-WiFi-Stick/index.md
@@ -10,7 +10,7 @@ difficulty: 3
 
 ## General Notes
 
-This configuration is for the [Solis S3 WiFi Stick](https://www.solisinverters.com/us/accessories5/WiFi_Data_Logging_Stick_us.html)
+This configuration is for the [Solis S3 WiFi Stick](https://www.solisinverters.com/in/accessories5/WiFi_Data_Logging_Stick_in.html)
 which reads usage data from Ginlong Solis solar inverters.
 
 ## Flashing Instuctions

--- a/src/docs/devices/VirageBridge/index.md
+++ b/src/docs/devices/VirageBridge/index.md
@@ -7,7 +7,7 @@ standard: global
 
 [Virage Laboratories](https://www.viragelabs.com)
 
-[VB-001 433 MHz to WiFi Bridge](https://www.viragelabs.com/product/viragebridge/)![image](virage_labs_VB-001.jpg)
+[VB-001 433 MHz to WiFi Bridge](https://www.viragelabs.com/)![image](virage_labs_VB-001.jpg)
 
 ## General Notes
 

--- a/src/docs/devices/VirageDimmer/index.md
+++ b/src/docs/devices/VirageDimmer/index.md
@@ -7,7 +7,7 @@ standard: us
 
 [Virage Laboratories](https://www.viragelabs.com)
 
-[KS-7012 Dimmer](https://www.viragelabs.com/product/viragedimmer/)![image](virage_labs_KS-7012.jpg)
+[KS-7012 Dimmer](https://www.viragelabs.com/)![image](virage_labs_KS-7012.jpg)
 
 ## General Notes
 

--- a/src/docs/devices/ViragePlug/index.md
+++ b/src/docs/devices/ViragePlug/index.md
@@ -7,7 +7,7 @@ standard: us
 
 [Virage Laboratories](https://www.viragelabs.com)
 
-[KS-604S Outlet](https://www.viragelabs.com/product/virageplug/)![image](virage_labs_KS-604S.jpg)
+[KS-604S Outlet](https://www.viragelabs.com/)![image](virage_labs_KS-604S.jpg)
 
 ## General Notes
 

--- a/src/docs/devices/VirageSwitch/index.md
+++ b/src/docs/devices/VirageSwitch/index.md
@@ -7,7 +7,7 @@ standard: us
 
 [Virage Laboratories](https://www.viragelabs.com)
 
-[KS-602H Switch](https://www.viragelabs.com/product/virageswitch/)![image](virage_labs_KS-602H.jpg)
+[KS-602H Switch](https://www.viragelabs.com/)![image](virage_labs_KS-602H.jpg)
 
 ## General Notes
 


### PR DESCRIPTION
## Summary
Fixes several broken external links reported in #1576.

## Changes
- Updated Athom E27 15W Bulb link to current product page
- Updated Athom E27 7W Bulb link to current product page
- Updated Solis S3 WiFi Stick link (US page removed, pointing to active product page)
- Fixed Virage Labs product links for ViragePlug, VirageDimmer, VirageSwitch, and VirageBridge (website changed ownership, product pages no longer exist)

## Related issue
Partially addresses #1576