### PR TITLE
Fail the Made for ESPHome review on any secret, Wi-Fi pair included

### DIFF
--- a/.github/made-for-esphome-checklist.md
+++ b/.github/made-for-esphome-checklist.md
@@ -12,8 +12,13 @@
     - [ ] Configuration includes `dashboard_import:` to facilitate this ([documentation](https://esphome.io/components/esphome.html#adding-the-mac-address-as-a-suffix-to-the-device-name))
     - [ ] Configuration contains the `ota`.`esphome` component ([documentation](https://esphome.io/components/ota/esphome))
     - [ ] Serial flashing is not disabled
-    - [ ] There are no references to secrets in the configuration
-    - [ ] There are no passwords in the configuration
+    - [ ] There are no references to secrets in the configuration - not even
+          `!secret wifi_ssid` / `!secret wifi_password`. Users provision their
+          own Wi-Fi credentials, so anything baked in only leaves dummy values
+          in the device's storage; secrets belong in the configuration a user
+          ends up with **after** taking control
+    - [ ] There are no passwords in the configuration - neither literal values
+          nor `!secret` references on any `password:` / `psk:` key
     - [ ] There are no static IP addresses in the configuration
     - [ ] The configuration **must** be valid, compile and run successfully _without any user changes_ after taking control
     - [ ] Every entity/component (sensor, switch, etc.) **must** have an `id` defined

--- a/scripts/review-made-for-esphome.test.ts
+++ b/scripts/review-made-for-esphome.test.ts
@@ -12,6 +12,7 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
+import yaml from "js-yaml";
 
 import {
   parseGitHubYamlUrl,
@@ -19,7 +20,8 @@ import {
   collectMissingIds,
   collectBakedPasswords,
   collectManualIps,
-  collectStraySecrets,
+  collectSecretRefs,
+  placeholderSecretsYaml,
   runChecklist,
   pageBlocks,
   buildReport,
@@ -125,29 +127,45 @@ test("collectMissingIds requires id on every component, incl. buses/hubs", () =>
   assert.equal(uptime.name, "Uptime");
 });
 
-test("collectBakedPasswords distinguishes secrets, empties and literals", () => {
+test("collectBakedPasswords flags every non-empty password, secrets included", () => {
   const cfg = {
     ota: [
       { platform: "esphome", password: "" }, // empty -> fine
-      { platform: "http_request", password: "!secret ota_pw" }, // non-wifi secret on a password key -> flag
+      { platform: "http_request", password: "!secret ota_pw" }, // secret ref -> flag
     ],
     wifi: {
-      ap: { password: "!secret wifi_password" }, // allowed wifi secret -> fine
-      password: "!secret wifi_password", // allowed wifi secret -> fine
+      // The Wi-Fi pair is NOT exempt: a shipped config must carry no
+      // credentials at all, so both of these are flagged.
+      ap: { password: "!secret wifi_password" },
+      password: "!secret wifi_password",
     },
     // `key:` is not a password/psk key, so this is NOT a collectBakedPasswords
-    // concern — a non-wifi secret here is caught by collectStraySecrets and by
-    // `esphome config` failing to resolve it.
+    // concern: a secret here is caught by collectSecretRefs instead.
     api: { encryption: { key: "!secret api_key" } },
     mqtt: { password: "hunter2" }, // literal -> flag
     some: { psk: "0011aabb" }, // psk literal -> flag
   };
   const out: string[] = [];
   collectBakedPasswords(cfg, [], out);
-  assert.equal(out.length, 3, out.join(" | "));
+  assert.equal(out.length, 5, out.join(" | "));
   assert.ok(out.some((s) => s.includes("ota.1.password") && s.includes("ota_pw")));
+  assert.ok(
+    out.some(
+      (s) => s.includes("wifi.password") && s.includes("!secret wifi_password")
+    )
+  );
+  assert.ok(
+    out.some(
+      (s) =>
+        s.includes("wifi.ap.password") && s.includes("!secret wifi_password")
+    )
+  );
   assert.ok(out.some((s) => s.includes("mqtt.password")));
   assert.ok(out.some((s) => s.includes("some.psk")));
+  // A password key that is only whitespace still counts as empty.
+  const blank: string[] = [];
+  collectBakedPasswords({ ota: [{ password: "  " }] }, [], blank);
+  assert.deepEqual(blank, []);
 });
 
 test("collectManualIps finds static IPs under wifi/ethernet only", () => {
@@ -161,13 +179,16 @@ test("collectManualIps finds static IPs under wifi/ethernet only", () => {
   assert.deepEqual(collectManualIps({ wifi: {} }), []);
 });
 
-test("collectStraySecrets ignores the wifi pair, catches others", () => {
-  assert.equal(
-    collectStraySecrets("a: !secret wifi_ssid\nb: !secret 'wifi_password'").size,
-    0
+test("collectSecretRefs catches every secret, wifi pair included", () => {
+  assert.deepEqual(
+    [
+      ...collectSecretRefs("a: !secret wifi_ssid\nb: !secret 'wifi_password'"),
+    ].sort(),
+    ["wifi_password", "wifi_ssid"]
   );
-  const stray = collectStraySecrets("k: !secret api_key\nj: !secret ota_pw");
-  assert.deepEqual([...stray].sort(), ["api_key", "ota_pw"]);
+  const refs = collectSecretRefs("k: !secret api_key\nj: !secret ota_pw");
+  assert.deepEqual([...refs].sort(), ["api_key", "ota_pw"]);
+  assert.equal(collectSecretRefs("wifi:\n  ap: {}\n").size, 0);
 });
 
 test("stripAnsi removes literal and real escape sequences", () => {
@@ -211,9 +232,9 @@ const GOOD_CFG = {
     project: { name: "Acme.Widget" },
   },
   esp32: { board: "esp32dev", variant: "ESP32" },
+  // A compliant shipped config provisions Wi-Fi over Improv and carries no
+  // credentials at all: no `ssid:`/`password:`, no `!secret` references.
   wifi: {
-    ssid: "!secret wifi_ssid",
-    password: "!secret wifi_password",
     ap: { password: "" },
   },
   esp32_improv: {},
@@ -226,12 +247,7 @@ const GOOD_CFG = {
 };
 
 test("runChecklist passes a compliant config", () => {
-  const checks = runChecklist(
-    GOOD_CFG,
-    "wifi:\n  password: !secret wifi_password",
-    "Widget",
-    "PASS"
-  );
+  const checks = runChecklist(GOOD_CFG, "wifi:\n  ap: {}\n", "Widget", "PASS");
   const bad = checks.filter(
     (c) => c.status === "MISSING" || c.status === "FAIL"
   );
@@ -269,10 +285,89 @@ test("runChecklist flags a non-compliant config", () => {
   assert.equal(byItem.get("ota: `- platform: esphome`"), "MISSING");
   assert.equal(byItem.get("update: `- platform: http_request`"), "MISSING");
   assert.equal(byItem.get("No passwords in the configuration"), "FAIL");
-  assert.equal(byItem.get("No references to non-standard secrets"), "FAIL");
+  assert.equal(byItem.get("No references to secrets in the configuration"), "FAIL");
   assert.equal(byItem.get("No static IP addresses"), "FAIL");
   assert.equal(byItem.get("Every entity/component has an `id:`"), "MISSING");
   assert.equal(byItem.get("Compiles without user changes"), "FAIL");
+});
+
+// The rule the programme actually enforces: a manufacturer's shipped config
+// must contain NO secrets, the `wifi_ssid`/`wifi_password` pair included.
+// Users provision their own Wi-Fi credentials, so baking the pair in only
+// leaves dummy values in device storage; secrets belong in the config the user
+// ends up with after taking control.
+test("runChecklist fails a shipped config that references the Wi-Fi secrets", () => {
+  const cfg = {
+    ...GOOD_CFG,
+    wifi: {
+      ssid: "!secret wifi_ssid",
+      password: "!secret wifi_password",
+      ap: { password: "" },
+    },
+  };
+  const expanded = [
+    "wifi:",
+    "  ssid: !secret wifi_ssid",
+    "  password: !secret wifi_password",
+    "",
+  ].join("\n");
+  const checks = runChecklist(cfg, expanded, "Widget", "PASS");
+  const byItem = new Map(checks.map((c) => [c.item, c]));
+
+  const passwords = byItem.get("No passwords in the configuration")!;
+  assert.equal(passwords.status, "FAIL");
+  assert.ok(passwords.detail.includes("wifi.password"));
+  assert.ok(passwords.detail.includes("!secret wifi_password"));
+
+  const secrets = byItem.get("No references to secrets in the configuration")!;
+  assert.equal(secrets.status, "FAIL");
+  assert.ok(secrets.detail.includes("!secret wifi_ssid"));
+  assert.ok(secrets.detail.includes("!secret wifi_password"));
+
+  // Everything else about the config is fine; these two are the only
+  // failures, and they are enough to block the page.
+  assert.deepEqual(
+    checks
+      .filter((c) => c.status === "FAIL" || c.status === "MISSING")
+      .map((c) => c.item),
+    [
+      "No passwords in the configuration",
+      "No references to secrets in the configuration",
+    ]
+  );
+  const result: PageResult = {
+    page: "p",
+    url: "u",
+    fenceMissing: false,
+    fatalError: null,
+    configOk: true,
+    configInconclusive: false,
+    configError: null,
+    compile: "PASS",
+    compileLog: null,
+    checks,
+  };
+  assert.equal(pageBlocks(result), true);
+});
+
+// The placeholder secrets are the review tool's own, written so that a config
+// referencing the Wi-Fi pair still expands and compiles; they must never
+// double as an allowlist for the checks above.
+test("placeholderSecretsYaml keeps the compile step working", () => {
+  const body = placeholderSecretsYaml();
+  assert.equal(
+    body,
+    'wifi_ssid: "placeholder_ssid"\nwifi_password: "placeholder_password"\n'
+  );
+  const parsed = yaml.load(body) as Record<string, string>;
+  assert.deepEqual(Object.keys(parsed).sort(), ["wifi_password", "wifi_ssid"]);
+  // Exactly the names the checklist now flags: supplying them lets
+  // `esphome config`/`compile` run, while the config is still reported as
+  // non-compliant.
+  const flagged = collectSecretRefs(
+    "a: !secret wifi_ssid\nb: !secret wifi_password"
+  );
+  assert.deepEqual([...flagged].sort(), Object.keys(parsed).sort());
 });
 
 test("esp32_improv is N/A when there is no wifi", () => {

--- a/scripts/review-made-for-esphome.test.ts
+++ b/scripts/review-made-for-esphome.test.ts
@@ -191,6 +191,37 @@ test("collectSecretRefs catches every secret, wifi pair included", () => {
   assert.equal(collectSecretRefs("wifi:\n  ap: {}\n").size, 0);
 });
 
+// Secret names are arbitrary YAML keys. A name-character class of
+// `[A-Za-z0-9_]` truncated hyphenated names (merging `ha-key` and `ha-token`
+// into one `ha`) and matched no double-quoted name at all, which made the
+// check silently pass on `!secret "wifi_ssid"`.
+test("collectSecretRefs handles quoted, hyphenated and flow-style names", () => {
+  assert.deepEqual([...collectSecretRefs('a: !secret "wifi_ssid"')], [
+    "wifi_ssid",
+  ]);
+  assert.deepEqual(
+    [...collectSecretRefs("a: !secret ha-key\nb: !secret ha-token")].sort(),
+    ["ha-key", "ha-token"]
+  );
+  assert.deepEqual([...collectSecretRefs("a: !secret 'ha-key'")], ["ha-key"]);
+  // Flow sequences and trailing comments must not swallow the terminator.
+  assert.deepEqual(
+    [...collectSecretRefs("a: [!secret one, !secret two]")].sort(),
+    ["one", "two"]
+  );
+  assert.deepEqual([...collectSecretRefs("a: !secret three # comment")], [
+    "three",
+  ]);
+  // The same name in different quoting styles is one secret.
+  assert.deepEqual(
+    [...collectSecretRefs("a: !secret k\nb: !secret 'k'\nc: !secret \"k\"")],
+    ["k"]
+  );
+  // The regex is module-level; a previous call must not leave lastIndex set.
+  assert.equal(collectSecretRefs("a: !secret k").size, 1);
+  assert.equal(collectSecretRefs("a: !secret k").size, 1);
+});
+
 test("stripAnsi removes literal and real escape sequences", () => {
   assert.equal(stripAnsi("\\033[8m\\033[28m"), "");
   assert.equal(stripAnsi("\\033[8mmotor-1\\033[28m"), "motor-1");

--- a/scripts/review-made-for-esphome.ts
+++ b/scripts/review-made-for-esphome.ts
@@ -669,11 +669,22 @@ function collectBakedPasswords(
 // so anything baked in only leaves dummy values sitting in device storage.
 // Secrets belong in the configuration a user ends up with AFTER taking
 // control, never in what the manufacturer ships.
+//
+// Secret names are arbitrary YAML keys, so match all three forms `esphome
+// config` can emit: double-quoted, single-quoted, and bare. A bare name runs
+// to the first whitespace or YAML flow terminator. Matching only
+// `[A-Za-z0-9_]` would truncate a hyphenated name (`ha-key` -> `ha`, merging
+// distinct secrets) and miss a double-quoted one entirely, which would make
+// this check silently pass.
+const SECRET_REF_RE = /!secret\s+(?:"([^"]+)"|'([^']+)'|([^\s,\]}#]+))/g;
+
 function collectSecretRefs(text: string): Set<string> {
   const refs = new Set<string>();
-  const re = /!secret\s+'?([A-Za-z0-9_]+)'?/g;
+  SECRET_REF_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
-  while ((m = re.exec(text)) !== null) refs.add(m[1]);
+  while ((m = SECRET_REF_RE.exec(text)) !== null) {
+    refs.add(m[1] ?? m[2] ?? m[3]);
+  }
   return refs;
 }
 
@@ -898,7 +909,8 @@ function runChecklist(
           : "NEEDS-HUMAN-CHECK";
   const compileDetail =
     compile === "PASS"
-      ? "`esphome compile` succeeded against the configuration as shipped"
+      ? "`esphome compile` succeeded, with only a placeholder `secrets.yaml` " +
+        "supplied by this review"
       : compile === "FAIL"
         ? "`esphome compile` failed — see the compile log above"
         : compile === "INCONCLUSIVE"
@@ -1457,7 +1469,10 @@ function renderPage(r: PageResult): string {
   }
   lines.push("- ✅ `esphome config` — configuration expands and validates");
   if (r.compile === "PASS") {
-    lines.push("- ✅ `esphome compile` — builds as shipped, without user changes");
+    lines.push(
+      "- ✅ `esphome compile` — builds with only a placeholder `secrets.yaml` " +
+        "supplied by this review"
+    );
   } else if (r.compile === "FAIL") {
     lines.push("- ❌ `esphome compile` — failed to build (see log below)");
   } else if (r.compile === "INCONCLUSIVE") {
@@ -1506,8 +1521,9 @@ function buildReport(pages: PageResult[]): string {
     lines.push("");
     lines.push(
       "All automated Made for ESPHome checks pass. Each page below was compiled " +
-        "from its linked upstream config exactly as shipped, then checked " +
-        `against the [Made for ESPHome checklist](${CHECKLIST_URL}). ` +
+        "from its linked upstream config, with only a placeholder " +
+        "`secrets.yaml` supplied by this review, then checked against the " +
+        `[Made for ESPHome checklist](${CHECKLIST_URL}). ` +
         "A maintainer will take a final look before approval. Items marked ⚠️ " +
         "still need a human to confirm (e.g. whether the hardware has a USB port)."
     );
@@ -1517,9 +1533,9 @@ function buildReport(pages: PageResult[]): string {
     lines.push(
       `The automated Made for ESPHome checks found blocking issues on ` +
         `**${blocking.length} page${blocking.length === 1 ? "" : "s"}**. ` +
-        "Each page below was compiled from its linked upstream config exactly " +
-        "as shipped, then checked against the " +
-        `[Made for ESPHome checklist](${CHECKLIST_URL}). ` +
+        "Each page below was compiled from its linked upstream config, with " +
+        "only a placeholder `secrets.yaml` supplied by this review, then " +
+        `checked against the [Made for ESPHome checklist](${CHECKLIST_URL}). ` +
         "Address the items marked ❌ and push an update — this review refreshes " +
         "automatically and is dismissed once the checks pass. Items marked ⚠️ " +
         "need a human to confirm (e.g. whether the hardware has a USB port)."

--- a/scripts/review-made-for-esphome.ts
+++ b/scripts/review-made-for-esphome.ts
@@ -11,11 +11,14 @@
  *   2. Downloads the whole upstream repo tree at the pinned ref (not just the
  *      one file) so relative `!include`s and sibling packages resolve exactly
  *      as they do upstream.
- *   3. Writes a `secrets.yaml` next to the config containing ONLY placeholder
- *      `wifi_ssid` / `wifi_password` — the pair the ESPHome Builder supplies
- *      on adoption. A dependency on any OTHER `!secret` therefore makes
- *      expansion fail, which is itself a valid "does not build without user
- *      secrets" finding.
+ *   3. Writes a `secrets.yaml` next to the config containing placeholder
+ *      `wifi_ssid` / `wifi_password`. Those placeholders are OURS, not the
+ *      manufacturer's: they exist so that a config which (wrongly) references
+ *      that pair still expands and compiles, letting us report the whole
+ *      checklist instead of one opaque expansion error. A dependency on any
+ *      OTHER `!secret` makes expansion fail, which is itself a valid "does
+ *      not build without user secrets" finding. Either way, a shipped config
+ *      must reference no secrets at all - see check 11.
  *   4. Runs `esphome config <file>` to fully expand packages/includes/removes
  *      and validate the schema, capturing the expanded document.
  *   5. If that succeeds, runs `esphome compile <file>` to prove the config
@@ -68,13 +71,28 @@ import yaml from "js-yaml";
 const URL_HOST_ALLOWLIST = new Set(["github.com", "raw.githubusercontent.com"]);
 const YAML_EXT = /\.ya?ml$/i;
 
-// The only secrets we provide. Any config that references anything else fails
-// `esphome config` — surfaced as a "depends on user secrets" finding.
+// Placeholder values this script injects into a `secrets.yaml` of its own so
+// `esphome config` / `esphome compile` can run against the manufacturer's
+// config at all. This is NOT an allowlist: a shipped config that references
+// `!secret wifi_ssid` / `!secret wifi_password` still fails the "no secrets in
+// the configuration" checklist item. The placeholders only keep the compile
+// step meaningful, so that failure is reported alongside the rest of the
+// checklist rather than replacing it. Any config referencing a secret we do
+// not define fails `esphome config`, surfaced as a "depends on user secrets"
+// finding instead.
 const PLACEHOLDER_SECRETS: Record<string, string> = {
   wifi_ssid: "placeholder_ssid",
   wifi_password: "placeholder_password",
 };
-const ALLOWED_SECRET_NAMES = new Set(Object.keys(PLACEHOLDER_SECRETS));
+
+// Body of the `secrets.yaml` we drop next to the manufacturer's config.
+function placeholderSecretsYaml(): string {
+  return (
+    Object.entries(PLACEHOLDER_SECRETS)
+      .map(([k, v]) => `${k}: "${v}"`)
+      .join("\n") + "\n"
+  );
+}
 
 const CHECKLIST_URL =
   "https://github.com/esphome/esphome-devices/blob/main/.github/made-for-esphome-checklist.md";
@@ -508,10 +526,11 @@ function classifyConfigError(r: ExecResult): {
   if (secret) {
     return {
       message:
-        `config depends on \`!secret ${secret[1]}\` — the ESPHome Builder only ` +
-        "supplies `wifi_ssid`/`wifi_password` on adoption, so this will not " +
-        "build out of the box. Provide a sensible default in the config instead " +
-        "of requiring the user to define this secret.",
+        `config depends on \`!secret ${secret[1]}\`, which is not defined. A ` +
+        "shipped Made for ESPHome configuration must reference no secrets at " +
+        "all, so this will not build out of the box. Provide a sensible " +
+        "default in the config instead of requiring the user to define this " +
+        "secret.",
       network: false,
     };
   }
@@ -605,11 +624,12 @@ function describeMissingId(m: MissingId): string {
   return `\`${m.domain}\`${plat}${label}`;
 }
 
-// Walk the expanded tree for password/psk keys carrying a baked-in credential.
-// After `esphome config`, `!secret` refs survive as `"!secret <name>"` strings;
-// the only defined secrets are the wifi pair, so a surviving `!secret` is
-// always user-supplied wifi creds and is fine. Any non-empty literal is a
-// baked-in password and is flagged.
+// Walk the expanded tree for password/psk keys carrying a credential. After
+// `esphome config`, `!secret` refs survive as `"!secret <name>"` strings. Made
+// for ESPHome permits neither form on a password key: a literal is a baked-in
+// password, and a `!secret` reference (the `wifi_password` pair included) is
+// a credential the user must supply before the config works. Only an empty
+// value (e.g. ota `password: ""`) passes.
 const PASSWORD_KEY = /^([\w-]*password[\w-]*|psk)$/i;
 
 function collectBakedPasswords(
@@ -632,12 +652,9 @@ function collectBakedPasswords(
       if (trimmed === "") {
         // empty password (e.g. ota `password: ""`) is fine
       } else if (isSecretRef) {
-        // Surviving !secret => wifi pair (only defined secrets) => fine.
-        if (!ALLOWED_SECRET_NAMES.has(isSecretRef[1])) {
-          out.push(
-            `\`${[...pathStack, key].join(".")}\` references \`!secret ${isSecretRef[1]}\``
-          );
-        }
+        out.push(
+          `\`${[...pathStack, key].join(".")}\` references \`!secret ${isSecretRef[1]}\``
+        );
       } else {
         out.push(`\`${[...pathStack, key].join(".")}\` has a baked-in value`);
       }
@@ -646,16 +663,18 @@ function collectBakedPasswords(
   }
 }
 
-// Any non-wifi `!secret` that survived expansion (belt-and-suspenders: config
-// would normally have failed first).
-function collectStraySecrets(text: string): Set<string> {
-  const stray = new Set<string>();
+// Every `!secret` reference that survived expansion, the `wifi_ssid` /
+// `wifi_password` pair included. A Made for ESPHome configuration ships with
+// no secrets at all: users provision their own Wi-Fi credentials over Improv,
+// so anything baked in only leaves dummy values sitting in device storage.
+// Secrets belong in the configuration a user ends up with AFTER taking
+// control, never in what the manufacturer ships.
+function collectSecretRefs(text: string): Set<string> {
+  const refs = new Set<string>();
   const re = /!secret\s+'?([A-Za-z0-9_]+)'?/g;
   let m: RegExpExecArray | null;
-  while ((m = re.exec(text)) !== null) {
-    if (!ALLOWED_SECRET_NAMES.has(m[1])) stray.add(m[1]);
-  }
-  return stray;
+  while ((m = re.exec(text)) !== null) refs.add(m[1]);
+  return refs;
 }
 
 function collectManualIps(cfg: Record<string, unknown>): string[] {
@@ -830,17 +849,20 @@ function runChecklist(
     status: bakedPasswords.length ? "FAIL" : "OK",
     detail: bakedPasswords.length
       ? bakedPasswords.join("; ")
-      : "no baked-in passwords (user-supplied Wi-Fi secrets are fine)",
+      : "no passwords on any `password:`/`psk:` key",
   });
 
-  // 11. No secret references beyond the Wi-Fi pair.
-  const stray = collectStraySecrets(expandedText);
+  // 11. No secret references at all: the Wi-Fi pair is not exempt.
+  const secretRefs = collectSecretRefs(expandedText);
   checks.push({
-    item: "No references to non-standard secrets",
-    status: stray.size ? "FAIL" : "OK",
-    detail: stray.size
-      ? `references \`!secret\`: ${[...stray].map((s) => `\`${s}\``).join(", ")}`
-      : "only the standard `wifi_ssid`/`wifi_password` pair is referenced",
+    item: "No references to secrets in the configuration",
+    status: secretRefs.size ? "FAIL" : "OK",
+    detail: secretRefs.size
+      ? `references ${[...secretRefs]
+          .map((s) => `\`!secret ${s}\``)
+          .join(", ")}. The shipped configuration must contain no secrets; ` +
+        "users provision their own credentials after taking control"
+      : "no `!secret` references",
   });
 
   // 12. No static IPs.
@@ -876,7 +898,7 @@ function runChecklist(
           : "NEEDS-HUMAN-CHECK";
   const compileDetail =
     compile === "PASS"
-      ? "`esphome compile` succeeded with only placeholder Wi-Fi secrets"
+      ? "`esphome compile` succeeded against the configuration as shipped"
       : compile === "FAIL"
         ? "`esphome compile` failed — see the compile log above"
         : compile === "INCONCLUSIVE"
@@ -1288,11 +1310,14 @@ async function reviewPage(
   }
   const configDir = path.dirname(configFile);
 
-  // 3. Placeholder secrets next to the config.
-  const secretsBody = Object.entries(PLACEHOLDER_SECRETS)
-    .map(([k, v]) => `${k}: "${v}"`)
-    .join("\n");
-  fs.writeFileSync(path.join(configDir, "secrets.yaml"), secretsBody + "\n");
+  // 3. Placeholder secrets next to the config, so a config that references
+  //    the Wi-Fi pair still expands and compiles. Referencing it is still a
+  //    checklist failure (check 11); this only keeps the compile step, and
+  //    therefore the rest of the report, meaningful.
+  fs.writeFileSync(
+    path.join(configDir, "secrets.yaml"),
+    placeholderSecretsYaml()
+  );
 
   // 4. Expand + validate.
   const configTimeout = Number(process.env.CONFIG_TIMEOUT_MS ?? 180000);
@@ -1432,7 +1457,7 @@ function renderPage(r: PageResult): string {
   }
   lines.push("- ✅ `esphome config` — configuration expands and validates");
   if (r.compile === "PASS") {
-    lines.push("- ✅ `esphome compile` — builds with only placeholder Wi-Fi secrets");
+    lines.push("- ✅ `esphome compile` — builds as shipped, without user changes");
   } else if (r.compile === "FAIL") {
     lines.push("- ❌ `esphome compile` — failed to build (see log below)");
   } else if (r.compile === "INCONCLUSIVE") {
@@ -1481,8 +1506,8 @@ function buildReport(pages: PageResult[]): string {
     lines.push("");
     lines.push(
       "All automated Made for ESPHome checks pass. Each page below was compiled " +
-        "from its linked upstream config with only placeholder Wi-Fi secrets, " +
-        `then checked against the [Made for ESPHome checklist](${CHECKLIST_URL}). ` +
+        "from its linked upstream config exactly as shipped, then checked " +
+        `against the [Made for ESPHome checklist](${CHECKLIST_URL}). ` +
         "A maintainer will take a final look before approval. Items marked ⚠️ " +
         "still need a human to confirm (e.g. whether the hardware has a USB port)."
     );
@@ -1492,8 +1517,8 @@ function buildReport(pages: PageResult[]): string {
     lines.push(
       `The automated Made for ESPHome checks found blocking issues on ` +
         `**${blocking.length} page${blocking.length === 1 ? "" : "s"}**. ` +
-        "Each page below was compiled from its linked upstream config with only " +
-        "placeholder Wi-Fi secrets, then checked against the " +
+        "Each page below was compiled from its linked upstream config exactly " +
+        "as shipped, then checked against the " +
         `[Made for ESPHome checklist](${CHECKLIST_URL}). ` +
         "Address the items marked ❌ and push an update — this review refreshes " +
         "automatically and is dismissed once the checks pass. Items marked ⚠️ " +
@@ -1705,7 +1730,8 @@ export {
   collectMissingIds,
   collectBakedPasswords,
   collectManualIps,
-  collectStraySecrets,
+  collectSecretRefs,
+  placeholderSecretsYaml,
   runChecklist,
   pageBlocks,
   buildReport,


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

The automated Made for ESPHome review exempted `!secret wifi_ssid` / `!secret wifi_password` from both the "There are no passwords in the configuration" and "There are no references to secrets in the configuration" checklist items, so a manufacturer config shipping that pair passed the review clean. That contradicts the checklist: users provision their own Wi-Fi credentials, so anything baked in only leaves dummy values sitting in the device's storage. Secrets belong in the configuration a user ends up with **after** taking control, not in what ships on the device.

`scripts/review-made-for-esphome.ts` now flags every `!secret` reference and every non-empty `password:`/`psk:` value, with no exemption for the Wi-Fi pair. `ALLOWED_SECRET_NAMES` is gone; `collectStraySecrets` became `collectSecretRefs`, and check 11 is renamed to "No references to secrets in the configuration" to match the checklist item verbatim.

The distinction that matters is preserved: `PLACEHOLDER_SECRETS` is still written to a `secrets.yaml` that the review tool drops beside the manufacturer's config, so `esphome config` and `esphome compile` still run against a config that references the pair. Those placeholders are the tool's own, not an allowlist - they exist so a non-compliant config is reported as failing two checklist items alongside a full report, rather than dying with one opaque expansion error. Verified end to end against a real `esphome config` run: a fixture referencing the pair expands successfully (exit 0) and fails exactly those two checks, while the same fixture with the two lines removed passes all fourteen.

`scripts/validate-yaml-configs.ts` already forbade every `!secret` and every non-empty password key for in-repo example yaml, so it needed no change - this brings the Made for ESPHome reviewer in line with it.

`.github/made-for-esphome-checklist.md` gets the same rule spelled out, since both items were previously silent on the Wi-Fi pair and that is exactly where the tooling had drifted.

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [x] Other

## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

This PR touches only the review tooling and the Made for ESPHome checklist document - no device page or example yaml is added or modified, so the items below do not apply. `npm run validate-devices` (779 devices, 21 yaml files), `npm run validate-yaml`, `npm run lint-frontmatter` and `npm test` (77 pass, 0 fail) are all green.

- [ ] Adding a new device adds a single device only — one device per pull request.
- [ ] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [ ] The first `file=` fence on the page references `config.yaml`.
- [ ] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [ ] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->