### PR TITLE
Added proxy configuration for Sonoff RF Bridge

### DIFF
--- a/src/docs/devices/Sonoff-RF-Bridge/index.md
+++ b/src/docs/devices/Sonoff-RF-Bridge/index.md
@@ -79,6 +79,7 @@ binary_sensor:
 
 
 remote_receiver:
+  id: rf_receiver
   pin: 4
 #  dump: all
   dump: rc_switch
@@ -87,8 +88,20 @@ remote_receiver:
   idle: 2ms
 
 remote_transmitter:
+  id: rf_transmitter
   pin: 5
   carrier_duty_percent: 100%
+
+radio_frequency:
+  - platform: ir_rf_proxy
+    frequency: 433.92MHz
+    name: RF Proxy Transmitter
+    id: ir_proxy_tx
+    remote_transmitter_id: rf_transmitter
+  - platform: ir_rf_proxy
+    name: RF Proxy Receiver
+    id: ir_proxy_rx
+    remote_receiver_id: rf_receiver
 
 status_led:
   pin:


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes
This adds the RF proxy configuration to the Sonoff RF Bridge (As tested on my own RF bridge with [Direct Hack](https://github.com/xoseperez/espurna/wiki/Hardware-Itead-Sonoff-RF-Bridge---Direct-Hack) as seems to be the case with the rest of the config as well)

I've tested the proxy using the KlikAanKlikUit Home Assistant integration.

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [x] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [ ] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [ ] The first `file=` fence on the page references `config.yaml`.
- [ ] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [ ] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml` or the `raw.githubusercontent.com` equivalent) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

## Questions:

A quick double check, i'm reading 
> `config.yaml` is **hardware-only**: no top-level ... ``bluetooth_proxy:` ... anywhere in the tree.

In https://github.com/esphome/rf-proxies/blob/main/README.md i'm reading
> If a device is not included here it may have a suitable configuration in the [ESPHome Device Configuration Repository](https://devices.esphome.io/).

Am i correct the RF proxies do not fall under this rule?