### PR TITLE
Validate the "Type of changes" checklist in the label PR workflow

### DIFF
--- a/.github/scripts/label-pr-type.cjs
+++ b/.github/scripts/label-pr-type.cjs
@@ -1,0 +1,184 @@
+// Reads the "Type of changes" section of the pull request description and
+// applies the matching type label (new-device / update-device / remove-device
+// / cleanup / other) based on which checkbox is ticked. The labels themselves
+// already exist in the repo; this script only keeps them in sync.
+//
+// The section is also validated: a missing section, no ticked box, more than
+// one ticked box, a malformed tick (stray spaces inside the brackets, e.g.
+// `[ x]` or `[x ]`), or a ticked line that doesn't match any known box all
+// fail the job so the author gets a clear message on what to fix. A failing
+// run still syncs labels first - an invalid description clears any
+// previously applied managed label, since it no longer represents a single
+// valid selection.
+//
+// Pull requests opened by bots (Dependabot and friends) never carry the
+// template, so they are skipped entirely rather than failed.
+//
+// Loaded by .github/workflows/label-pr-type.yml via actions/github-script.
+// Exported as a function so it can be linted (`node --check`) and
+// unit-tested with a mocked GitHub client. The pure parser is exported
+// separately so its edge cases can be tested without a GitHub client at all.
+
+// `match` is anchored at the start of the checkbox's label text so an
+// unrelated box (e.g. "Another …") can't match by substring. Every entry is a
+// "managed" label: unticking (or invalidating) the section removes it again.
+const LABELS = [
+  { name: "new-device", match: /^new device\b/i },
+  { name: "update-device", match: /^update existing device\b/i },
+  { name: "remove-device", match: /^removing a device\b/i },
+  { name: "cleanup", match: /^general cleanup\b/i },
+  { name: "other", match: /^other\b/i },
+];
+
+// Isolate the "Type of changes" section so checkboxes in other sections
+// (e.g. the "Checklist:" block, which also mentions "new device") can never
+// trigger a label. \r?\n throughout so CRLF bodies (common from the web
+// editor) match.
+const SECTION = /##\s*Type of changes\s*\r?\n([\s\S]*?)(?:\r?\n##\s|$)/i;
+
+// Every list-item checkbox line in the section, however it's indented
+// (spaces or tabs) or bulleted (-, *, +). Group 1 is the exact bracket
+// content, so callers can tell a clean `x`/`X`/` ` apart from anything else
+// (a stray space, an empty box, a non-ASCII tick, ...). Group 2 is the label
+// text after the checkbox, trimmed of trailing whitespace.
+const CHECKBOX_LINE = /^[ \t]*[-*+][ \t]*\[([^\]]*)\][ \t]*(.*?)[ \t]*\r?$/gm;
+
+// Parses the "Type of changes" section of a pull request body.
+//
+// Returns `{ ticked, malformed, sectionFound }`:
+//   - `sectionFound` is false when the section itself is missing (including
+//     a null/undefined/empty body).
+//   - `ticked` holds the label text of every cleanly ticked box (bracket
+//     content exactly "x" or "X").
+//   - `malformed` holds the full trimmed line of every checkbox whose
+//     bracket content is neither a clean tick nor a clean blank " " (a stray
+//     space, an empty box, a non-ASCII mark, ...).
+function parseTypeOfChanges(body) {
+  const ticked = [];
+  const malformed = [];
+  if (!body) {
+    return { ticked, malformed, sectionFound: false };
+  }
+  const section = SECTION.exec(body);
+  if (!section) {
+    return { ticked, malformed, sectionFound: false };
+  }
+
+  const scoped = section[1];
+  CHECKBOX_LINE.lastIndex = 0;
+  let m;
+  while ((m = CHECKBOX_LINE.exec(scoped)) !== null) {
+    const mark = m[1];
+    if (mark === " ") {
+      continue;
+    }
+    if (mark === "x" || mark === "X") {
+      ticked.push(m[2]);
+      continue;
+    }
+    malformed.push(m[0].trim());
+  }
+  return { ticked, malformed, sectionFound: true };
+}
+
+module.exports = async ({ github, context, core }) => {
+  const pr = context.payload.pull_request;
+  const { owner, repo } = context.repo;
+
+  // Bots (Dependabot, GitHub Actions, ...) don't fill in the pull request
+  // template, so there is nothing to validate or label for them.
+  if (pr.user && pr.user.type === "Bot") {
+    core.info(`PR #${pr.number} was opened by ${pr.user.login} (a bot); nothing to do.`);
+    return;
+  }
+
+  const { ticked, malformed, sectionFound } = parseTypeOfChanges(pr.body);
+
+  // Map each ticked text to the label it drives. `matched` is the distinct
+  // set of labels found; `unrecognised` is any ticked text that matched none
+  // of them (a box that isn't from the current template).
+  const matched = [];
+  const unrecognised = [];
+  for (const text of ticked) {
+    const label = LABELS.find((l) => l.match.test(text));
+    if (!label) {
+      unrecognised.push(text);
+    } else if (!matched.includes(label.name)) {
+      matched.push(label.name);
+    }
+  }
+
+  const problems = [];
+  if (!sectionFound) {
+    problems.push(
+      'The pull request description has no "## Type of changes" section. ' +
+        "Please restore the pull request template and tick exactly one box."
+    );
+  }
+  for (const line of malformed) {
+    problems.push(
+      `Malformed checkbox: \`${line}\`. Tick a box as \`- [x]\` with no spaces inside the brackets.`
+    );
+  }
+  for (const text of unrecognised) {
+    problems.push(
+      `Unrecognised ticked box: \`${text}\`. ` +
+        "Only the boxes from the pull request template are accepted."
+    );
+  }
+  const noneMatched = malformed.length === 0 && unrecognised.length === 0 && matched.length === 0;
+  if (sectionFound && noneMatched) {
+    problems.push('No "Type of changes" box is ticked. Please tick exactly one.');
+  }
+  if (matched.length > 1) {
+    problems.push(
+      `Multiple "Type of changes" boxes are ticked (${matched.join(", ")}). ` +
+        "Please tick exactly one."
+    );
+  }
+
+  // An invalid description doesn't represent a single valid selection, so it
+  // clears any managed label a previous (valid) run applied.
+  const desired = new Set(problems.length === 0 ? matched : []);
+  core.info(`Desired type labels: ${[...desired].join(", ") || "(none)"}`);
+
+  const managed = new Set(LABELS.map((l) => l.name));
+  const current = new Set(pr.labels.map((l) => l.name));
+
+  const toAdd = [...desired].filter((name) => !current.has(name));
+  const toRemove = [...managed].filter((name) => current.has(name) && !desired.has(name));
+
+  if (toAdd.length) {
+    await github.rest.issues.addLabels({
+      owner,
+      repo,
+      issue_number: pr.number,
+      labels: toAdd,
+    });
+    core.info(`Added: ${toAdd.join(", ")}`);
+  }
+
+  for (const name of toRemove) {
+    await github.rest.issues.removeLabel({
+      owner,
+      repo,
+      issue_number: pr.number,
+      name,
+    });
+    core.info(`Removed: ${name}`);
+  }
+
+  if (!toAdd.length && !toRemove.length) {
+    core.info("Labels already in sync.");
+  }
+
+  if (problems.length) {
+    core.setFailed(
+      'The "Type of changes" section of the pull request description is invalid:\n' +
+        problems.map((p) => `- ${p}`).join("\n")
+    );
+  }
+};
+
+module.exports.parseTypeOfChanges = parseTypeOfChanges;
+module.exports.LABELS = LABELS;

--- a/.github/workflows/label-pr-type.yml
+++ b/.github/workflows/label-pr-type.yml
@@ -36,6 +36,9 @@ jobs:
           sparse-checkout: |
             .github/scripts
           sparse-checkout-cone-mode: false
+          # The script only needs the file on disk; don't leave the token in
+          # .git/config for any later step to pick up.
+          persist-credentials: false
 
       - name: Sync labels from checklist
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0

--- a/.github/workflows/label-pr-type.yml
+++ b/.github/workflows/label-pr-type.yml
@@ -2,9 +2,13 @@ name: Label PR by type
 
 # Reads the "Type of changes" section of the pull request description and
 # applies the matching type label (new-device / update-device / remove-device /
-# cleanup / other) based on which checkboxes are ticked. Runs again whenever the
+# cleanup / other) based on which checkbox is ticked. Runs again whenever the
 # description is edited, so ticking or unticking a box keeps the labels in sync.
 # The labels themselves already exist in the repo.
+#
+# The section is also validated: the job fails when no box is ticked, more
+# than one box is ticked, or a tick is malformed (e.g. `[ x]` or `[x ]`).
+# Pull requests opened by bots (e.g. Dependabot) are skipped.
 
 on:
   pull_request_target:
@@ -20,76 +24,22 @@ jobs:
     name: Sync type labels
     runs-on: ubuntu-latest
     permissions:
+      contents: read  # to check out the script below
       issues: write  # labels are an issues-level resource
       pull-requests: write  # add/remove labels on the PR
     steps:
+      # Checks out the base repo (trusted) only to load the script below,
+      # never the PR's code - this job runs with a writable token.
+      - name: Checkout scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+
       - name: Sync labels from checklist
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
-            // Maps a checkbox under "## Type of changes" to the label it drives.
-            // `match` is anchored at the start of the checkbox's label text so an
-            // unrelated box (e.g. "Another …") can't match by substring. Every
-            // entry is a "managed" label: unticking a box removes it again.
-            const LABELS = [
-              { name: 'new-device', match: /^new device\b/i },
-              { name: 'update-device', match: /^update existing device\b/i },
-              { name: 'remove-device', match: /^removing a device\b/i },
-              { name: 'cleanup', match: /^general cleanup\b/i },
-              { name: 'other', match: /^other\b/i },
-            ];
-
-            const pr = context.payload.pull_request;
-            const body = pr.body || '';
-
-            // Isolate the "Type of changes" section so checkboxes in other
-            // sections (e.g. the "Checklist:" block, which also mentions
-            // "new device") can never trigger a label.
-            // \r?\n throughout so CRLF bodies (common from the web editor) match.
-            const section = body.match(/##\s*Type of changes\s*\r?\n([\s\S]*?)(?:\r?\n##\s|$)/i);
-            const scoped = section ? section[1] : '';
-
-            // Collect the text of every ticked checkbox in that section.
-            const ticked = [];
-            const checkbox = /^\s*-\s*\[[xX]\]\s*(.+?)\s*$/gm;
-            let m;
-            while ((m = checkbox.exec(scoped)) !== null) {
-              ticked.push(m[1]);
-            }
-
-            const desired = new Set(
-              LABELS.filter((l) => ticked.some((t) => l.match.test(t))).map((l) => l.name)
-            );
-            core.info(`Desired type labels: ${[...desired].join(', ') || '(none)'}`);
-
-            const managed = new Set(LABELS.map((l) => l.name));
-            const current = new Set(pr.labels.map((l) => l.name));
-
-            const toAdd = [...desired].filter((name) => !current.has(name));
-            const toRemove = [...managed].filter(
-              (name) => current.has(name) && !desired.has(name)
-            );
-
-            if (toAdd.length) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                labels: toAdd,
-              });
-              core.info(`Added: ${toAdd.join(', ')}`);
-            }
-
-            for (const name of toRemove) {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                name,
-              });
-              core.info(`Removed: ${name}`);
-            }
-
-            if (!toAdd.length && !toRemove.length) {
-              core.info('Labels already in sync.');
-            }
+            const script = require('./.github/scripts/label-pr-type.cjs');
+            await script({ github, context, core });

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "validate-devices": "tsx scripts/validate-devices.ts && tsx scripts/validate-yaml-configs.ts",
     "validate-yaml": "tsx scripts/validate-yaml-configs.ts",
     "review-made-for-esphome": "tsx scripts/review-made-for-esphome.ts",
-    "check-workflow-scripts": "node --check .github/scripts/mfe-review-feedback.cjs && node --check .github/scripts/mfe-review-command.cjs && node --check .github/scripts/mfe-intake.cjs && node --check .github/scripts/mfe-promote.cjs",
+    "check-workflow-scripts": "node --check .github/scripts/mfe-review-feedback.cjs && node --check .github/scripts/mfe-review-command.cjs && node --check .github/scripts/mfe-intake.cjs && node --check .github/scripts/mfe-promote.cjs && node --check .github/scripts/label-pr-type.cjs",
     "test": "npm run --silent check-workflow-scripts && tsx --test scripts/*.test.ts",
     "extract-yaml": "tsx scripts/extract-inline-yaml.ts",
     "extract-yaml:check": "tsx scripts/extract-inline-yaml.ts --check",

--- a/scripts/label-pr-type.test.ts
+++ b/scripts/label-pr-type.test.ts
@@ -1,0 +1,275 @@
+#!/usr/bin/env tsx
+/**
+ * Unit tests for the extracted github-script handler used by the
+ * "Label PR by type" workflow:
+ *   .github/scripts/label-pr-type.cjs
+ *
+ * Covers both the pure `parseTypeOfChanges` parser and the full handler
+ * (label sync + validation), exercised with a recording GitHub client mock -
+ * no network. Run with `npm test`.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const script = require("../.github/scripts/label-pr-type.cjs");
+const { parseTypeOfChanges } = script as {
+  parseTypeOfChanges: (body: string | null | undefined) => {
+    ticked: string[];
+    malformed: string[];
+    sectionFound: boolean;
+  };
+};
+
+type Call = { method: string; args: unknown };
+
+// A GitHub client mock that records addLabels/removeLabel calls.
+function makeGithub() {
+  const calls: Call[] = [];
+  const github = {
+    rest: {
+      issues: {
+        addLabels: async (args: unknown) => {
+          calls.push({ method: "addLabels", args });
+          return { data: {} };
+        },
+        removeLabel: async (args: unknown) => {
+          calls.push({ method: "removeLabel", args });
+          return { data: {} };
+        },
+      },
+    },
+  };
+  return { github, calls };
+}
+
+function freshCore() {
+  return {
+    info: () => {},
+    setFailed(m: string) {
+      (this._failed as string[]).push(m);
+    },
+    _failed: [] as string[],
+  };
+}
+
+// Builds the pull_request_target payload the handler reads, and runs it.
+async function run(
+  body: string | null,
+  currentLabels: string[],
+  user: { login: string; type: string } = { login: "someone", type: "User" }
+) {
+  const { github, calls } = makeGithub();
+  const core = freshCore();
+  const context = {
+    repo: { owner: "esphome", repo: "esphome-devices" },
+    payload: {
+      pull_request: {
+        number: 7,
+        body,
+        user,
+        labels: currentLabels.map((name) => ({ name })),
+      },
+    },
+  };
+  await script({ github, context, core });
+  return { calls, core };
+}
+
+const addedLabels = (calls: Call[]) =>
+  calls
+    .filter((c) => c.method === "addLabels")
+    .flatMap((c) => (c.args as { labels: string[] }).labels);
+
+const removedLabels = (calls: Call[]) =>
+  calls.filter((c) => c.method === "removeLabel").map((c) => (c.args as { name: string }).name);
+
+// The exact box text from .github/PULL_REQUEST_TEMPLATE.md, reproduced
+// verbatim (including the em dash, which is upstream template text).
+const NEW_DEVICE_BOX = "New device (a single device only — one device per pull request)";
+
+function section(lines: string): string {
+  return `# Brief description\n\n## Type of changes\n\n${lines}\n\n## Checklist:\n\n- [ ] x\n`;
+}
+
+// --- parseTypeOfChanges ------------------------------------------------------
+
+test("parse: null body -> section not found", () => {
+  const result = parseTypeOfChanges(null);
+  assert.equal(result.sectionFound, false);
+  assert.deepEqual(result.ticked, []);
+  assert.deepEqual(result.malformed, []);
+});
+
+test("parse: undefined and empty body -> section not found", () => {
+  assert.equal(parseTypeOfChanges(undefined).sectionFound, false);
+  assert.equal(parseTypeOfChanges("").sectionFound, false);
+});
+
+test("parse: section present with only unticked boxes -> nothing ticked or malformed", () => {
+  const body = section("- [ ] New device\n- [ ] Other");
+  const result = parseTypeOfChanges(body);
+  assert.equal(result.sectionFound, true);
+  assert.deepEqual(result.ticked, []);
+  assert.deepEqual(result.malformed, []);
+});
+
+test("parse: CRLF body with a clean uppercase tick", () => {
+  const body = "## Type of changes\r\n- [X] Other\r\n\r\n## Checklist:\r\n- [ ] x\r\n";
+  const result = parseTypeOfChanges(body);
+  assert.equal(result.sectionFound, true);
+  assert.deepEqual(result.ticked, ["Other"]);
+  assert.deepEqual(result.malformed, []);
+});
+
+test("parse: tab-indented asterisk bullet is recognised", () => {
+  const body = section("\t* [x] General cleanup");
+  const result = parseTypeOfChanges(body);
+  assert.deepEqual(result.ticked, ["General cleanup"]);
+  assert.deepEqual(result.malformed, []);
+});
+
+const MALFORMED_VARIANTS = ["[ x]", "[x ]", "[ x ]", "[X ]", "[]", "[✓]"];
+
+for (const variant of MALFORMED_VARIANTS) {
+  test(`parse: malformed checkbox ${variant} reported as the full trimmed line`, () => {
+    const line = `- ${variant} New device`;
+    const body = section(line);
+    const result = parseTypeOfChanges(body);
+    assert.deepEqual(result.ticked, []);
+    assert.deepEqual(result.malformed, [line]);
+  });
+}
+
+test("parse: checkboxes outside the section are ignored", () => {
+  const body =
+    "## Type of changes\n\n- [ ] New device\n\n" +
+    "## Checklist:\n\n- [x] Adding a new device adds a single device only.\n";
+  const result = parseTypeOfChanges(body);
+  assert.equal(result.sectionFound, true);
+  assert.deepEqual(result.ticked, []);
+  assert.deepEqual(result.malformed, []);
+});
+
+test("parse: section at the end of the body with no trailing heading", () => {
+  const body = "## Type of changes\n\n- [x] Other\n";
+  const result = parseTypeOfChanges(body);
+  assert.equal(result.sectionFound, true);
+  assert.deepEqual(result.ticked, ["Other"]);
+});
+
+// --- handler: valid selections ----------------------------------------------
+
+test("handler: a single valid tick labels new-device", async () => {
+  const body = section(`- [x] ${NEW_DEVICE_BOX}`);
+  const { calls, core } = await run(body, []);
+  assert.deepEqual(addedLabels(calls), ["new-device"]);
+  assert.deepEqual(removedLabels(calls), []);
+  assert.equal(core._failed.length, 0);
+});
+
+test("handler: label already present -> no add, already in sync, no failure", async () => {
+  const body = section(`- [x] ${NEW_DEVICE_BOX}`);
+  const { calls, core } = await run(body, ["new-device"]);
+  assert.equal(calls.filter((c) => c.method === "addLabels").length, 0);
+  assert.equal(calls.filter((c) => c.method === "removeLabel").length, 0);
+  assert.equal(core._failed.length, 0);
+});
+
+test("handler: switching selection adds the new label and removes the old one", async () => {
+  const body = section("- [x] General cleanup");
+  const { calls, core } = await run(body, ["update-device"]);
+  assert.deepEqual(addedLabels(calls), ["cleanup"]);
+  assert.deepEqual(removedLabels(calls), ["update-device"]);
+  assert.equal(core._failed.length, 0);
+});
+
+test("handler: duplicate ticks mapping to the same label count once, no failure", async () => {
+  const body = section("- [x] Other\n- [X] Other thing");
+  const { calls, core } = await run(body, []);
+  assert.deepEqual(addedLabels(calls), ["other"]);
+  assert.equal(core._failed.length, 0);
+});
+
+// --- handler: invalid selections ---------------------------------------------
+
+test("handler: no tick removes a previously managed label; non-managed untouched", async () => {
+  const body = section("- [ ] New device\n- [ ] Other");
+  const { calls, core } = await run(body, ["new-device", "made-for-esphome"]);
+  assert.deepEqual(addedLabels(calls), []);
+  assert.deepEqual(removedLabels(calls), ["new-device"]);
+  assert.equal(core._failed.length, 1);
+  assert.match(core._failed[0], /No "Type of changes" box is ticked/);
+});
+
+test("handler: two ticks fails with both names and adds nothing", async () => {
+  const body = section(`- [x] ${NEW_DEVICE_BOX}\n- [x] Other`);
+  const { calls, core } = await run(body, []);
+  assert.deepEqual(addedLabels(calls), []);
+  assert.equal(core._failed.length, 1);
+  assert.match(core._failed[0], /Multiple "Type of changes" boxes are ticked/);
+  assert.match(core._failed[0], /new-device/);
+  assert.match(core._failed[0], /other/);
+});
+
+test("handler: malformed tick fails, and a valid tick elsewhere is not labeled", async () => {
+  const body = section(`- [ x] Other\n- [x] ${NEW_DEVICE_BOX}`);
+  const { calls, core } = await run(body, []);
+  assert.deepEqual(addedLabels(calls), []);
+  assert.equal(core._failed.length, 1);
+  assert.match(core._failed[0], /Malformed checkbox: `- \[ x\] Other`/);
+});
+
+test("handler: unrecognised ticked text fails with the right message", async () => {
+  const body = section("- [x] Something else entirely");
+  const { calls, core } = await run(body, []);
+  assert.deepEqual(addedLabels(calls), []);
+  assert.equal(core._failed.length, 1);
+  assert.match(core._failed[0], /Unrecognised ticked box: `Something else entirely`/);
+});
+
+test("handler: missing section fails with no-section message", async () => {
+  const body = "# Brief description\n\nNo template here.\n";
+  const { calls, core } = await run(body, []);
+  assert.deepEqual(addedLabels(calls), []);
+  assert.equal(core._failed.length, 1);
+  assert.match(core._failed[0], /has no "## Type of changes" section/);
+});
+
+test("handler: missing body (null) fails the same as a missing section", async () => {
+  const { calls, core } = await run(null, []);
+  assert.deepEqual(addedLabels(calls), []);
+  assert.equal(core._failed.length, 1);
+  assert.match(core._failed[0], /has no "## Type of changes" section/);
+});
+
+test("handler: an invalid description still strips a previously applied label", async () => {
+  const body = section(`- [x] ${NEW_DEVICE_BOX}\n- [x] Other`);
+  const { calls, core } = await run(body, ["new-device"]);
+  assert.deepEqual(addedLabels(calls), []);
+  assert.deepEqual(removedLabels(calls), ["new-device"]);
+  assert.equal(core._failed.length, 1);
+});
+
+// --- handler: bots -----------------------------------------------------------
+
+test("handler: a bot-authored PR is skipped entirely, even with no template", async () => {
+  const body = "Bumps foo from 1.0.0 to 1.1.0.";
+  const bot = { login: "dependabot[bot]", type: "Bot" };
+  const { calls, core } = await run(body, ["new-device"], bot);
+  assert.deepEqual(calls, []);
+  assert.equal(core._failed.length, 0);
+});
+
+test("handler: a payload without a user is validated normally", async () => {
+  const { github, calls } = makeGithub();
+  const core = freshCore();
+  const context = {
+    repo: { owner: "esphome", repo: "esphome-devices" },
+    payload: { pull_request: { number: 7, body: null, labels: [] } },
+  };
+  await script({ github, context, core });
+  assert.deepEqual(calls, []);
+  assert.equal(core._failed.length, 1);
+});


### PR DESCRIPTION
<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

The "Label PR by type" workflow now validates the "## Type of changes" section of the PR description instead of silently doing nothing when it can't find a tick. The job fails with a clear message when the section is missing, no box is ticked, more than one box is ticked, a ticked box isn't one of the template's boxes, or a tick is malformed - `[ x]`, `[x ]`, `[ x ]`, `[]`, `[✓]` and so on, which is a common mistake. An invalid description also strips any previously applied type label so labels only ever mirror a valid selection. PRs opened by bots (Dependabot etc.) never carry the template and are skipped.

The logic moves out of the inline github-script into `.github/scripts/label-pr-type.cjs`, following the same pattern as the Made for ESPHome workflow scripts, so it can be syntax-checked in `check-workflow-scripts` and unit-tested. `scripts/label-pr-type.test.ts` covers the parser and the handler at 100% line and branch coverage.

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [x] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [ ] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [ ] The first `file=` fence on the page references `config.yaml`.
- [ ] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [ ] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub, Codeberg or GitLab repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml`, the `raw.githubusercontent.com` equivalent, `codeberg.org/<owner>/<repo>/(src|raw)/(branch|tag|commit)/<ref>/<path>.yaml`, or `gitlab.com/<owner>/<repo>/-/(blob|raw)/<ref>/<path>.yaml`) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->