### PR TITLE
Fix device name in configuration example

### DIFF
--- a/src/docs/devices/Shelly-1PM-Mini-Gen3/index.md
+++ b/src/docs/devices/Shelly-1PM-Mini-Gen3/index.md
@@ -40,7 +40,7 @@ The UART Pinout is the same as other Shelly Plus Mini.
 
 ```yaml
 esphome:
-  name: "sehlly-1pm-mini-gen3"
+  name: "shelly-1pm-mini-gen3"
   friendly_name: "Shelly 1PM Mini Gen3"
 
 esp32:


### PR DESCRIPTION
fixed typo in the Basic Config

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->

# Brief description of the changes

fixed typo in the Basic Config

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [ ] Update existing device
- [ ] Removing a device
- [X] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [ ] Adding a new device adds a single device only — one device per pull request.
- [ ] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [ ] The first `file=` fence on the page references `config.yaml`.
- [ ] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [ ] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub, Codeberg or GitLab repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml`, the `raw.githubusercontent.com` equivalent, `codeberg.org/<owner>/<repo>/(src|raw)/(branch|tag|commit)/<ref>/<path>.yaml`, or `gitlab.com/<owner>/<repo>/-/(blob|raw)/<ref>/<path>.yaml`) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
