### PR TITLE
Add Levoit Everest Air

### DIFF
--- a/src/docs/devices/Levoit-Everest-Air/config.yaml
+++ b/src/docs/devices/Levoit-Everest-Air/config.yaml
@@ -15,7 +15,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/tuct/levoit
-      ref: 1.4.2
+      ref: 1.4.3
     components: [levoit]
 
 wifi:

--- a/src/docs/devices/Levoit-Everest-Air/config.yaml
+++ b/src/docs/devices/Levoit-Everest-Air/config.yaml
@@ -99,6 +99,11 @@ binary_sensor:
     id: levoit_filter_low
     name: "Filter Low"
     type: filter_low
+  - platform: levoit
+    levoit: purifier
+    id: levoit_cover_open
+    name: "Cover Open"
+    type: cover_open
 
 number:
   - platform: levoit
@@ -106,6 +111,11 @@ number:
     id: levoit_timer
     name: "Timer (min)"
     type: timer
+  - platform: levoit
+    levoit: purifier
+    id: levoit_filter_lifetime
+    name: "Filter Months"
+    type: filter_lifetime_months
   - platform: levoit
     levoit: purifier
     id: levoit_vent_angle

--- a/src/docs/devices/Levoit-Everest-Air/config.yaml
+++ b/src/docs/devices/Levoit-Everest-Air/config.yaml
@@ -14,7 +14,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/tuct/levoit
-      ref: main
+      ref: 1.4.2
     components: [levoit]
 
 wifi:

--- a/src/docs/devices/Levoit-Everest-Air/config.yaml
+++ b/src/docs/devices/Levoit-Everest-Air/config.yaml
@@ -1,0 +1,127 @@
+esphome:
+  name: levoit-everest-air
+  friendly_name: Levoit Everest Air
+  name_add_mac_suffix: true
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_FREERTOS_UNICORE: y
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/tuct/levoit
+      ref: main
+    components: [levoit]
+
+wifi:
+  # Set up a wifi access point using the device name above
+  ap:
+
+uart:
+  - id: uart_mcu2esp
+    tx_pin: GPIO17
+    rx_pin: GPIO16
+    baud_rate: 115200
+
+levoit:
+  id: purifier
+  model: EVERESTAIR
+
+fan:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_fan
+    name: "Fan"
+
+switch:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_display
+    name: "Display"
+    type: display
+  - platform: levoit
+    levoit: purifier
+    id: levoit_child_lock
+    name: "Child Lock"
+    type: child_lock
+  - platform: levoit
+    levoit: purifier
+    id: levoit_light_detect
+    name: "Light Detect"
+    type: light_detect
+
+select:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_auto_mode
+    name: "Auto Mode"
+    type: auto_mode
+
+sensor:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_pm1
+    name: "AQ - PM 1.0"
+    type: pm1_0
+  - platform: levoit
+    levoit: purifier
+    id: levoit_pm25
+    name: "AQ - PM 2.5"
+    type: pm25
+  - platform: levoit
+    levoit: purifier
+    id: levoit_pm10
+    name: "AQ - PM 10"
+    type: pm10
+  - platform: levoit
+    levoit: purifier
+    id: levoit_aqi
+    name: "AQI"
+    type: aqi
+  - platform: levoit
+    levoit: purifier
+    id: levoit_cadr
+    name: "Current CADR"
+    type: current_cadr
+  - platform: levoit
+    levoit: purifier
+    id: levoit_filter_life
+    name: "Filter %"
+    type: filter_life_left
+
+binary_sensor:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_filter_low
+    name: "Filter Low"
+    type: filter_low
+
+number:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_timer
+    name: "Timer (min)"
+    type: timer
+  - platform: levoit
+    levoit: purifier
+    id: levoit_vent_angle
+    name: "Vent Angle"
+    type: vent_angle
+
+button:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_reset_filter
+    name: "Filter Reset"
+    type: reset_filter_stats
+
+text_sensor:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_mcu_version
+    name: "MCU Version"
+    type: mcu_version

--- a/src/docs/devices/Levoit-Everest-Air/config.yaml
+++ b/src/docs/devices/Levoit-Everest-Air/config.yaml
@@ -2,6 +2,7 @@ esphome:
   name: levoit-everest-air
   friendly_name: Levoit Everest Air
   name_add_mac_suffix: true
+  min_version: 2026.5.3
 
 esp32:
   board: esp32dev

--- a/src/docs/devices/Levoit-Everest-Air/index.md
+++ b/src/docs/devices/Levoit-Everest-Air/index.md
@@ -49,6 +49,11 @@ Take a backup of the stock firmware before writing anything over it.
 
 ## Basic Configuration
 
+> The configuration below is hardware-only, which is what this site's pages carry.
+> It has no `wifi:` credentials and no `api:` or `ota:` blocks, so add your own before
+> flashing — without them the device will not reach Home Assistant or accept OTA
+> updates.
+
 ```yaml file=config.yaml
 ```
 

--- a/src/docs/devices/Levoit-Everest-Air/index.md
+++ b/src/docs/devices/Levoit-Everest-Air/index.md
@@ -42,8 +42,17 @@ Three screws in the top get you to the control board. The device
 the teardown, the UART test points, and the alternative of wiring in a replacement
 ESP32 rather than reflashing the original.
 
-The UART pins in the configuration below follow the original ESP32-SOLO-1 mapping —
-RX on TP82, TX on TP33. Verify them against your own board before flashing.
+### GPIO Pinout
+
+The UART mapping below follows the original ESP32-SOLO-1. Verify it against your own
+board before flashing.
+
+| ESPHome pin | Test point | Function |
+|-------------|-----------|----------|
+| `GPIO16` | `TP82` | UART RX — MCU TX to ESP RX |
+| `GPIO17` | `TP33` | UART TX — ESP TX to MCU RX |
+
+Baud rate is 115200 8N1.
 
 Take a backup of the stock firmware before writing anything over it.
 

--- a/src/docs/devices/Levoit-Everest-Air/index.md
+++ b/src/docs/devices/Levoit-Everest-Air/index.md
@@ -1,0 +1,58 @@
+---
+title: "Levoit Everest Air"
+date-published: 2026-09-11
+type: misc
+standard: eu, us, uk
+board: esp32
+difficulty: 3
+project-url: https://github.com/tuct/levoit/tree/main/devices/levoit-everest-air
+---
+
+## Description
+
+Levoit's flagship purifier — 612 m³/h CADR, a 3-channel particulate sensor reporting
+PM1.0, PM2.5 and PM10, and a motorised vent louver. The Wi-Fi module and the
+purifier's own control MCU are separate chips joined by a 115200 8N1 UART link, so
+flashing ESPHome onto the stock Wi-Fi ESP32 keeps every hardware function working —
+the [`levoit`](https://github.com/tuct/levoit/tree/main/components/levoit) external
+component speaks the MCU's binary protocol.
+
+Tested against MCU firmware 1.0.2. The stock module is an ESP32-SOLO-1.
+
+Manufacturer: [Levoit](https://www.levoit.com)
+
+## Features
+
+* Fan with 3 manual speeds and Manual / Auto / Sleep / Turbo presets
+* Auto Mode select — Default / Eco
+* Vent Angle number — the motorised louver, 45–90°
+* Cover Open binary sensor — the unit powers off while the back door is open
+* Display, Child Lock and Light Detect switches — the last auto-dims the display in the dark
+* PM1.0, PM2.5, PM10 and AQI sensors
+* Current CADR sensor in m³/h, updated every 5 s
+* Filter life remaining sensor and a Filter Low binary sensor that trips under 5 %
+* Configurable filter lifetime in months, with a counter reset button
+* Run timer in minutes
+* MCU firmware version text sensor
+
+## Flashing
+
+Three screws in the top get you to the control board. The device
+[guide](https://github.com/tuct/levoit/tree/main/devices/levoit-everest-air) covers
+the teardown, the UART test points, and the alternative of wiring in a replacement
+ESP32 rather than reflashing the original.
+
+The UART pins in the configuration below follow the original ESP32-SOLO-1 mapping —
+RX on TP82, TX on TP33. Verify them against your own board before flashing.
+
+Take a backup of the stock firmware before writing anything over it.
+
+## Basic Configuration
+
+```yaml file=config.yaml
+```
+
+## Details and instructions
+
+Full teardown, PCB photos, wiring and the complete entity list:
+[tuct/levoit — Levoit Everest Air](https://github.com/tuct/levoit/tree/main/devices/levoit-everest-air).


### PR DESCRIPTION
# Brief description of the changes

Adds the Levoit Everest Air — 612 m³/h CADR, a 3-channel particulate sensor reporting PM1.0,
PM2.5 and PM10, and a motorised vent louver exposed as a number.

The Wi-Fi module and the control MCU are separate chips on a 115200 8N1 UART link, driven through
the `levoit` external component. Tested against MCU firmware 1.0.2 on the stock ESP32-SOLO-1.

`config.yaml` validates with `esphome config` on ESPHome 2026.7.0.

## Type of changes

- [x] New device (a single device only — one device per pull request)
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [x] Adding a new device adds a single device only — one device per pull request.
- [x] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [x] The first `file=` fence on the page references `config.yaml`.
- [x] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [x] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [x] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub, Codeberg or GitLab repo — n/a, these pages are not made-for-esphome.