### PR TITLE
Add Levoit Vital 100S

### DIFF
--- a/src/docs/devices/Levoit-Vital-100s/config.yaml
+++ b/src/docs/devices/Levoit-Vital-100s/config.yaml
@@ -2,6 +2,12 @@ esphome:
   name: levoit-vital100s
   friendly_name: Levoit Vital 100S
   name_add_mac_suffix: true
+  platformio_options:
+    # The stock ESP32-C3-SOLO-1 needs these; esp32-c3-devkitm-1 defaults to
+    # QIO at 80 MHz, which builds fine but can fail to boot on the original
+    # module.
+    board_build.flash_mode: dio
+    board_build.flash_freq: 40m
 
 esp32:
   board: esp32-c3-devkitm-1
@@ -99,9 +105,16 @@ number:
     type: timer
   - platform: levoit
     levoit: purifier
+    id: levoit_filter_lifetime
+    name: "Filter Months"
+    type: filter_lifetime_months
+  - platform: levoit
+    levoit: purifier
     id: levoit_room_size
     name: "Auto Mode Room Size"
     type: efficiency_room_size
+    min_value: 9
+    max_value: 52
 
 button:
   - platform: levoit

--- a/src/docs/devices/Levoit-Vital-100s/config.yaml
+++ b/src/docs/devices/Levoit-Vital-100s/config.yaml
@@ -2,6 +2,7 @@ esphome:
   name: levoit-vital100s
   friendly_name: Levoit Vital 100S
   name_add_mac_suffix: true
+  min_version: 2026.5.3
   platformio_options:
     # The stock ESP32-C3-SOLO-1 needs these; esp32-c3-devkitm-1 defaults to
     # QIO at 80 MHz, which builds fine but can fail to boot on the original
@@ -119,6 +120,13 @@ number:
     id: levoit_room_size
     name: "Auto Mode Room Size"
     type: efficiency_room_size
+    min_value: 9
+    max_value: 52
+  - platform: levoit
+    levoit: purifier
+    id: levoit_room_size_target
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
     min_value: 9
     max_value: 52
 

--- a/src/docs/devices/Levoit-Vital-100s/config.yaml
+++ b/src/docs/devices/Levoit-Vital-100s/config.yaml
@@ -23,7 +23,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/tuct/levoit
-      ref: 1.4.2
+      ref: 1.4.3
     components: [levoit]
 
 wifi:
@@ -103,10 +103,6 @@ binary_sensor:
     id: levoit_filter_low
     name: "Filter Low"
     type: filter_low
-    # The pinned 1.4.2 component defaults this to device_class: battery, which
-    # Home Assistant renders as a low-battery warning. Fixed upstream; override
-    # here until this page pins a release that carries the fix.
-    device_class: problem
 
 number:
   - platform: levoit

--- a/src/docs/devices/Levoit-Vital-100s/config.yaml
+++ b/src/docs/devices/Levoit-Vital-100s/config.yaml
@@ -5,9 +5,10 @@ esphome:
   platformio_options:
     # The stock ESP32-C3-SOLO-1 needs these; esp32-c3-devkitm-1 defaults to
     # QIO at 80 MHz, which builds fine but can fail to boot on the original
-    # module.
+    # module. board_build.f_flash is the key PlatformIO reads — flash_freq is
+    # silently ignored.
     board_build.flash_mode: dio
-    board_build.flash_freq: 40m
+    board_build.f_flash: 40000000L
 
 esp32:
   board: esp32-c3-devkitm-1
@@ -21,7 +22,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/tuct/levoit
-      ref: main
+      ref: 1.4.2
     components: [levoit]
 
 wifi:
@@ -89,6 +90,11 @@ sensor:
     id: levoit_filter_life
     name: "Filter %"
     type: filter_life_left
+  - platform: levoit
+    levoit: purifier
+    id: levoit_efficiency_counter
+    name: "Efficiency Counter"
+    type: efficiency_counter
 
 binary_sensor:
   - platform: levoit
@@ -129,3 +135,13 @@ text_sensor:
     id: levoit_mcu_version
     name: "MCU Version"
     type: mcu_version
+  - platform: levoit
+    levoit: purifier
+    id: levoit_high_fan_time
+    name: "Auto Mode High Fan Time"
+    type: auto_mode_room_size_high_fan
+  - platform: levoit
+    levoit: purifier
+    id: levoit_error
+    name: "Error"
+    type: error_message

--- a/src/docs/devices/Levoit-Vital-100s/config.yaml
+++ b/src/docs/devices/Levoit-Vital-100s/config.yaml
@@ -103,6 +103,10 @@ binary_sensor:
     id: levoit_filter_low
     name: "Filter Low"
     type: filter_low
+    # The pinned 1.4.2 component defaults this to device_class: battery, which
+    # Home Assistant renders as a low-battery warning. Fixed upstream; override
+    # here until this page pins a release that carries the fix.
+    device_class: problem
 
 number:
   - platform: levoit

--- a/src/docs/devices/Levoit-Vital-100s/config.yaml
+++ b/src/docs/devices/Levoit-Vital-100s/config.yaml
@@ -1,0 +1,118 @@
+esphome:
+  name: levoit-vital100s
+  friendly_name: Levoit Vital 100S
+  name_add_mac_suffix: true
+
+esp32:
+  board: esp32-c3-devkitm-1
+  variant: esp32c3
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_FREERTOS_UNICORE: y
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/tuct/levoit
+      ref: main
+    components: [levoit]
+
+wifi:
+  # Set up a wifi access point using the device name above
+  ap:
+
+uart:
+  - id: uart_mcu2esp
+    tx_pin: GPIO19
+    rx_pin: GPIO18
+    baud_rate: 115200
+
+levoit:
+  id: purifier
+  model: VITAL100S
+
+fan:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_fan
+    name: "Fan"
+
+switch:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_display
+    name: "Display"
+    type: display
+  - platform: levoit
+    levoit: purifier
+    id: levoit_child_lock
+    name: "Child Lock"
+    type: child_lock
+  - platform: levoit
+    levoit: purifier
+    id: levoit_light_detect
+    name: "Light Detect"
+    type: light_detect
+
+select:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_auto_mode
+    name: "Auto Mode"
+    type: auto_mode
+
+sensor:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_pm25
+    name: "AQ - PM 2.5"
+    type: pm25
+  - platform: levoit
+    levoit: purifier
+    id: levoit_aqi
+    name: "AQI"
+    type: aqi
+  - platform: levoit
+    levoit: purifier
+    id: levoit_cadr
+    name: "Current CADR"
+    type: current_cadr
+  - platform: levoit
+    levoit: purifier
+    id: levoit_filter_life
+    name: "Filter %"
+    type: filter_life_left
+
+binary_sensor:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_filter_low
+    name: "Filter Low"
+    type: filter_low
+
+number:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_timer
+    name: "Timer (min)"
+    type: timer
+  - platform: levoit
+    levoit: purifier
+    id: levoit_room_size
+    name: "Auto Mode Room Size"
+    type: efficiency_room_size
+
+button:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_reset_filter
+    name: "Filter Reset"
+    type: reset_filter_stats
+
+text_sensor:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_mcu_version
+    name: "MCU Version"
+    type: mcu_version

--- a/src/docs/devices/Levoit-Vital-100s/index.md
+++ b/src/docs/devices/Levoit-Vital-100s/index.md
@@ -46,6 +46,11 @@ Take a backup of the stock firmware before writing anything over it.
 
 ## Basic Configuration
 
+> The configuration below is hardware-only, which is what this site's pages carry.
+> It has no `wifi:` credentials and no `api:` or `ota:` blocks, so add your own before
+> flashing — without them the device will not reach Home Assistant or accept OTA
+> updates.
+
 ```yaml file=config.yaml
 ```
 

--- a/src/docs/devices/Levoit-Vital-100s/index.md
+++ b/src/docs/devices/Levoit-Vital-100s/index.md
@@ -1,0 +1,55 @@
+---
+title: "Levoit Vital 100S"
+date-published: 2026-09-11
+type: misc
+standard: eu, us, uk
+board: esp32
+difficulty: 3
+project-url: https://github.com/tuct/levoit/tree/main/devices/levoit-vital100s
+---
+
+## Description
+
+A smart air purifier with four fan speeds, a PM1003 particulate sensor and a Pet
+preset, rated at 221 m³/h. The Wi-Fi module and the purifier's own control MCU are
+separate chips joined by a 115200 8N1 UART link, so flashing ESPHome onto the stock
+Wi-Fi ESP32 keeps every hardware function working — the
+[`levoit`](https://github.com/tuct/levoit/tree/main/components/levoit) external
+component speaks the MCU's binary protocol.
+
+Tested against MCU firmware 1.0.5. The stock module is an ESP32-C3-SOLO-1.
+
+Manufacturer: [Levoit](https://www.levoit.com)
+
+## Features
+
+* Fan with 4 speeds and Manual / Auto / Sleep / Pet presets
+* Auto Mode select — Default / Quiet / Efficient
+* Auto Mode Room Size number (9–52 m²)
+* Efficiency counter sensor and a remaining high-fan-time text sensor for Efficient mode
+* Display, Child Lock and Light Detect switches — the last auto-dims the display in the dark
+* PM2.5 and AQI sensors
+* Current CADR sensor in m³/h, updated every 5 s
+* Filter life remaining sensor and a Filter Low binary sensor that trips under 5 %
+* Configurable filter lifetime in months, with a counter reset button
+* Run timer in minutes
+* MCU firmware version and error-status text sensors
+
+## Flashing
+
+The top cover pries off to expose the PCB — no screws to start with. The device
+[guide](https://github.com/tuct/levoit/tree/main/devices/levoit-vital100s) walks through opening
+the case without breaking the hooks, the UART pad locations, and the alternative of
+wiring in a replacement ESP32 rather than reflashing the original.
+
+Take a backup of the stock firmware before writing anything over it.
+
+## Basic Configuration
+
+```yaml file=config.yaml
+```
+
+## Details and instructions
+
+Full teardown, PCB photos, wiring and the complete entity list:
+[tuct/levoit — Levoit Vital 100S](https://github.com/tuct/levoit/tree/main/devices/levoit-vital100s).

--- a/src/docs/devices/Levoit-Vital-100s/index.md
+++ b/src/docs/devices/Levoit-Vital-100s/index.md
@@ -24,9 +24,11 @@ Manufacturer: [Levoit](https://www.levoit.com)
 ## Features
 
 * Fan with 4 speeds and Manual / Auto / Sleep / Pet presets
-* Auto Mode select — Default / Quiet / Efficient
-* Auto Mode Room Size number (9–52 m²)
-* Efficiency counter sensor and a remaining high-fan-time text sensor for Efficient mode
+* Auto Mode select — Default / Quiet / Room Size
+* Auto Mode Room Size number, 9–52 m² — the value the MCU reports
+* Auto Mode Room Size Preset number, 9–52 m² — the remembered target actually sent when
+  Room Size is selected, since the reported value reads 0 under Default/Quiet
+* Efficiency counter sensor and a remaining high-fan-time text sensor for Room Size mode
 * Display, Child Lock and Light Detect switches — the last auto-dims the display in the dark
 * PM2.5 and AQI sensors
 * Current CADR sensor in m³/h, updated every 5 s


### PR DESCRIPTION
# Brief description of the changes

Adds the Levoit Vital 100S — four fan speeds, a PM1003 particulate sensor and a Pet preset.

The Wi-Fi module and the control MCU are separate chips on a 115200 8N1 UART link, driven through
the `levoit` external component. Tested against MCU firmware 1.0.5 on the stock ESP32-C3-SOLO-1.

`config.yaml` validates with `esphome config` on ESPHome 2026.7.0.

## Type of changes

- [x] New device (a single device only — one device per pull request)
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [x] Adding a new device adds a single device only — one device per pull request.
- [x] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [x] The first `file=` fence on the page references `config.yaml`.
- [x] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [x] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [x] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub, Codeberg or GitLab repo — n/a, these pages are not made-for-esphome.