### PR TITLE
Add Levoit Core 600S

### DIFF
--- a/src/docs/devices/Levoit-Core-600s/config.yaml
+++ b/src/docs/devices/Levoit-Core-600s/config.yaml
@@ -15,7 +15,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/tuct/levoit
-      ref: 1.4.2
+      ref: 1.4.3
     components: [levoit]
 
 wifi:

--- a/src/docs/devices/Levoit-Core-600s/config.yaml
+++ b/src/docs/devices/Levoit-Core-600s/config.yaml
@@ -14,7 +14,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/tuct/levoit
-      ref: main
+      ref: 1.4.2
     components: [levoit]
 
 wifi:
@@ -122,3 +122,8 @@ text_sensor:
     id: levoit_mcu_version
     name: "MCU Version"
     type: mcu_version
+  - platform: levoit
+    levoit: purifier
+    id: levoit_error
+    name: "Error"
+    type: error_message

--- a/src/docs/devices/Levoit-Core-600s/config.yaml
+++ b/src/docs/devices/Levoit-Core-600s/config.yaml
@@ -2,6 +2,7 @@ esphome:
   name: levoit-core600s
   friendly_name: Levoit Core 600S
   name_add_mac_suffix: true
+  min_version: 2026.5.3
 
 esp32:
   board: esp32dev
@@ -106,6 +107,13 @@ number:
     id: levoit_room_size
     name: "Auto Mode Room Size"
     type: efficiency_room_size
+    min_value: 9
+    max_value: 147
+  - platform: levoit
+    levoit: purifier
+    id: levoit_room_size_target
+    name: "Auto Mode Room Size Preset"
+    type: auto_profile_room_size_input
     min_value: 9
     max_value: 147
 

--- a/src/docs/devices/Levoit-Core-600s/config.yaml
+++ b/src/docs/devices/Levoit-Core-600s/config.yaml
@@ -1,0 +1,117 @@
+esphome:
+  name: levoit-core600s
+  friendly_name: Levoit Core 600S
+  name_add_mac_suffix: true
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_FREERTOS_UNICORE: y
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/tuct/levoit
+      ref: main
+    components: [levoit]
+
+wifi:
+  # Set up a wifi access point using the device name above
+  ap:
+
+uart:
+  - id: uart_mcu2esp
+    tx_pin: GPIO17
+    rx_pin: GPIO16
+    baud_rate: 115200
+
+levoit:
+  id: purifier
+  model: CORE600S
+
+fan:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_fan
+    name: "Fan"
+
+switch:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_display
+    name: "Display"
+    type: display
+  - platform: levoit
+    levoit: purifier
+    id: levoit_child_lock
+    name: "Child Lock"
+    type: child_lock
+  - platform: levoit
+    levoit: purifier
+    id: levoit_light_detect
+    name: "Light Detect"
+    type: light_detect
+
+select:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_auto_mode
+    name: "Auto Mode"
+    type: auto_mode
+
+sensor:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_pm25
+    name: "AQ - PM 2.5"
+    type: pm25
+  - platform: levoit
+    levoit: purifier
+    id: levoit_aqi
+    name: "AQI"
+    type: aqi
+  - platform: levoit
+    levoit: purifier
+    id: levoit_cadr
+    name: "Current CADR"
+    type: current_cadr
+  - platform: levoit
+    levoit: purifier
+    id: levoit_filter_life
+    name: "Filter %"
+    type: filter_life_left
+
+binary_sensor:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_filter_low
+    name: "Filter Low"
+    type: filter_low
+
+number:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_timer
+    name: "Timer (min)"
+    type: timer
+  - platform: levoit
+    levoit: purifier
+    id: levoit_room_size
+    name: "Auto Mode Room Size"
+    type: efficiency_room_size
+
+button:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_reset_filter
+    name: "Filter Reset"
+    type: reset_filter_stats
+
+text_sensor:
+  - platform: levoit
+    levoit: purifier
+    id: levoit_mcu_version
+    name: "MCU Version"
+    type: mcu_version

--- a/src/docs/devices/Levoit-Core-600s/config.yaml
+++ b/src/docs/devices/Levoit-Core-600s/config.yaml
@@ -98,9 +98,16 @@ number:
     type: timer
   - platform: levoit
     levoit: purifier
+    id: levoit_filter_lifetime
+    name: "Filter Months"
+    type: filter_lifetime_months
+  - platform: levoit
+    levoit: purifier
     id: levoit_room_size
     name: "Auto Mode Room Size"
     type: efficiency_room_size
+    min_value: 9
+    max_value: 147
 
 button:
   - platform: levoit

--- a/src/docs/devices/Levoit-Core-600s/index.md
+++ b/src/docs/devices/Levoit-Core-600s/index.md
@@ -51,6 +51,11 @@ Take a backup of the stock firmware before writing anything over it.
 
 ## Basic Configuration
 
+> The configuration below is hardware-only, which is what this site's pages carry.
+> It has no `wifi:` credentials and no `api:` or `ota:` blocks, so add your own before
+> flashing — without them the device will not reach Home Assistant or accept OTA
+> updates.
+
 ```yaml file=config.yaml
 ```
 

--- a/src/docs/devices/Levoit-Core-600s/index.md
+++ b/src/docs/devices/Levoit-Core-600s/index.md
@@ -30,7 +30,9 @@ Manufacturer: [Levoit](https://www.levoit.com)
 
 * Fan with 4 speeds and Manual / Auto / Sleep presets
 * Auto Mode select — Default / Quiet / Room Size / ECO
-* Auto Mode Room Size number, 9–147 m²
+* Auto Mode Room Size number, 9–147 m² — the value the MCU reports
+* Auto Mode Room Size Preset number, 9–147 m² — the remembered target actually sent when
+  Room Size is selected, since the reported value reads 0 under Default/Quiet
 * Display, Child Lock and Light Detect switches — the last auto-dims the display in the dark
 * PM2.5 and AQI sensors
 * Current CADR sensor in m³/h, updated every 5 s

--- a/src/docs/devices/Levoit-Core-600s/index.md
+++ b/src/docs/devices/Levoit-Core-600s/index.md
@@ -1,0 +1,60 @@
+---
+title: "Levoit Core 600S"
+date-published: 2026-09-11
+type: misc
+standard: eu, us, uk
+board: esp32
+difficulty: 4
+project-url: https://github.com/tuct/levoit/tree/main/devices/levoit-core600s
+---
+
+## Description
+
+The largest of the Levoit Core range — 641 m³/h CADR, four fan speeds and four
+distinct auto profiles, with air quality from a Luftme LD15 sensor. The Wi-Fi module
+and the purifier's own control MCU are separate chips joined by a 115200 8N1 UART
+link, so flashing ESPHome onto the stock Wi-Fi ESP32 keeps every hardware function
+working — the
+[`levoit`](https://github.com/tuct/levoit/tree/main/components/levoit) external
+component speaks the MCU's binary protocol.
+
+Tested against MCU firmware 2.0.1.
+
+Check which module your unit has before flashing. Retail Core 600S units have been
+seen with different ESP32s; the configuration below is for the ESP32-SOLO-1C, and a
+C3-based unit needs the matching `esp32:` block instead.
+
+Manufacturer: [Levoit](https://www.levoit.com)
+
+## Features
+
+* Fan with 4 speeds and Manual / Auto / Sleep presets
+* Auto Mode select — Default / Quiet / Room Size / ECO
+* Auto Mode Room Size number, 9–147 m²
+* Display, Child Lock and Light Detect switches — the last auto-dims the display in the dark
+* PM2.5 and AQI sensors
+* Current CADR sensor in m³/h, updated every 5 s
+* Filter life remaining sensor and a Filter Low binary sensor that trips under 5 %
+* Configurable filter lifetime in months, with a counter reset button
+* Run timer in minutes
+* MCU firmware version and error-status text sensors
+
+## Flashing
+
+Disassembly is the most involved of the Levoit range: the fan assembly has to come
+out through the handles to reach the control board. The device
+[guide](https://github.com/tuct/levoit/tree/main/devices/levoit-core600s) has
+annotated photos of every step, the UART pads, and the alternative of wiring in a
+replacement ESP32 rather than reflashing the original.
+
+Take a backup of the stock firmware before writing anything over it.
+
+## Basic Configuration
+
+```yaml file=config.yaml
+```
+
+## Details and instructions
+
+Full teardown, PCB photos, wiring and the complete entity list:
+[tuct/levoit — Levoit Core 600S](https://github.com/tuct/levoit/tree/main/devices/levoit-core600s).


### PR DESCRIPTION
# Brief description of the changes

Adds the Levoit Core 600S — 641 m³/h CADR, four fan speeds, four auto profiles and a Luftme LD15
particulate sensor.

Same arrangement as the other Levoit units: the Wi-Fi module and the control MCU are separate chips
on a 115200 8N1 UART link, driven through the `levoit` external component. Tested against MCU
firmware 2.0.1. The page notes that retail units have shipped with different ESP32 modules, so the
`esp32:` block may need adjusting.

`config.yaml` validates with `esphome config` on ESPHome 2026.7.0.

## Type of changes

- [x] New device (a single device only — one device per pull request)
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [x] Adding a new device adds a single device only — one device per pull request.
- [x] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [x] The first `file=` fence on the page references `config.yaml`.
- [x] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [x] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [x] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub, Codeberg or GitLab repo — n/a, these pages are not made-for-esphome.