### PR TITLE
Update Levoit device pages - repoint source links to the current repo…

### DIFF
--- a/src/docs/devices/Levoit-Core-300s-enhanced/index.md
+++ b/src/docs/devices/Levoit-Core-300s-enhanced/index.md
@@ -6,6 +6,7 @@ standard: eu, us, uk
 board: esp32
 made-for-esphome: False
 difficulty: 4
+project-url: https://github.com/tuct/levoit/tree/main/devices/levoit-core300s
 ---
 
 ## Features
@@ -20,9 +21,11 @@ difficulty: 4
 
 ## General Notes
 
-A smart air purifier with 3-stage filtration. The ESP32 talks to the Tuya MCU using standard 8N1 115200-baud UART. Code
-and configuration were obtained from
-[Tuct's 'esphome-projects' repo](https://github.com/tuct/esphome-projects/tree/main/projects/levoit-core300s).
+A smart air purifier with 3-stage filtration. The ESP32 talks to the purifier's own
+control MCU over a standard 8N1 115200-baud UART link. Code and configuration come
+from the [`levoit`](https://github.com/tuct/levoit/tree/main/components/levoit)
+external component in
+[Tuct's 'levoit' repo](https://github.com/tuct/levoit/tree/main/devices/levoit-core300s).
 
 I had issues with those two implementations:
 [acvigue's 'esphome-levoit-air-purifier' repo](https://github.com/acvigue/esphome-levoit-air-purifier)
@@ -41,4 +44,4 @@ Manufacturer: [Levoit](http://www.levoit.com)
 
 ## Details and instructions
 
-[Tuct's 'esphome-projects' repo](https://github.com/tuct/esphome-projects/tree/main/projects/levoit-core300s).
+[Tuct's 'levoit' repo](https://github.com/tuct/levoit/tree/main/devices/levoit-core300s).

--- a/src/docs/devices/Levoit-Mini/index.md
+++ b/src/docs/devices/Levoit-Mini/index.md
@@ -6,6 +6,7 @@ standard: eu, us, uk
 board: esp32
 made-for-esphome: False
 difficulty: 4
+project-url: https://github.com/tuct/levoit/tree/main/devices/levoit-mini
 ---
 
 ## Features
@@ -20,12 +21,14 @@ difficulty: 4
 
 ## General Notes
 
-A air purifier with 3-stage filtration.
+An air purifier with 3-stage filtration.
 
-This project requires a custom PCB and 3D Printed parts to convert the Levoit Mini into  Levoit Mini-s (Smartified version)
+This project requires a custom PCB and 3D printed parts to convert the Levoit Mini
+into a Levoit Mini-S (smartified version). The original PCB is bypassed rather than
+modified, so the change is reversible.
 
 Manufacturer: [Levoit](http://www.levoit.com)
 
-More details and isntructionscan be found here:
+More details and instructions can be found here:
 
-[Tuct's 'esphome-projects' repo](https://github.com/tuct/esphome-projects/tree/main/projects/levoit-mini).
+[Tuct's 'levoit' repo](https://github.com/tuct/levoit/tree/main/devices/levoit-mini).


### PR DESCRIPTION
# Brief description of the changes

The Levoit Core 300s enhanced and Levoit Mini pages both link to `tuct/esphome-projects` under a
`projects/` path. That repo has since been renamed and restructured; the links only still resolve
because of GitHub's rename redirect, and they point at the old unmaintained folder rather than the
maintained one.

- Repoints both pages at `tuct/levoit` under `devices/`
- Adds `project-url` frontmatter to both
- Core 300s enhanced: corrects the description — the MCU is not a Tuya MCU — and links the `levoit`
  component directly
- Levoit Mini: fixes two typos and clarifies that the original PCB is bypassed rather than modified

Grouped as a single PR since this is the same cleanup applied to two pages. No configuration
changes.

## Type of changes

- [ ] New device (a single device only — one device per pull request)
- [ ] Update existing device
- [ ] Removing a device
- [x] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [x] Adding a new device adds a single device only — one device per pull request.
- [x] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [x] The first `file=` fence on the page references `config.yaml`.
- [x] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [x] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [x] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub, Codeberg or GitLab repo — n/a, these pages are not made-for-esphome.