### PR TITLE
Add M5Stack NanoH2

### DIFF
--- a/src/docs/devices/m5stack-nanoh2/config.yaml
+++ b/src/docs/devices/m5stack-nanoh2/config.yaml
@@ -1,0 +1,65 @@
+esphome:
+  name: m5stack-nanoh2
+  friendly_name: M5Stack NanoH2
+  name_add_mac_suffix: true
+
+esp32:
+  variant: esp32h2
+  framework:
+    type: esp-idf
+
+light:
+  - platform: status_led
+    name: "Status LED"
+    id: blue_status_led
+    entity_category: diagnostic
+    pin: GPIO4
+
+  - platform: esp32_rmt_led_strip
+    rgb_order: GRB
+    pin: GPIO11
+    num_leds: 1
+    chipset: ws2812
+    name: "RGB LED"
+    id: rgb_led
+    power_supply: rgb_pwr
+
+power_supply:
+  - id: rgb_pwr
+    pin: GPIO10
+
+    # According to the datasheet of the Awinic AW35122FDR, it takes the load
+    # switch 0.5ms to fully turn on (it has slew rate control), see "Switch
+    # turn on time".
+    enable_time: 5ms
+    keep_on_time: 10ms
+
+binary_sensor:
+  - platform: gpio
+    name: Button
+    id: case_button
+    pin:
+      number: GPIO9
+
+      # M5Stack intended to use GPIO9 for the button to allow the user to
+      # force the ESP into download mode. Acknowledge the warning from ESPHome.
+      # See "Download Mode" in https://docs.m5stack.com/en/core/NanoH2
+      ignore_strapping_warning: true
+
+      inverted: true
+      mode:
+        input: true
+        pullup: true
+    filters:
+      - delayed_off: 10ms
+
+remote_transmitter:
+  id: ir_tx
+  pin: GPIO3
+  carrier_duty_percent: 50%
+
+infrared:
+  - platform: ir_rf_proxy
+    name: IR Proxy Transmitter
+    id: ir_proxy_tx
+    remote_transmitter_id: ir_tx

--- a/src/docs/devices/m5stack-nanoh2/index.md
+++ b/src/docs/devices/m5stack-nanoh2/index.md
@@ -1,0 +1,34 @@
+---
+title: "M5Stack NanoH2"
+date-published: 2026-09-11
+type: misc
+standard: global
+board: esp32
+difficulty: 2
+project-url: https://docs.m5stack.com/en/core/NanoH2
+---
+
+## Description
+
+NanoH2 is an ultra-compact, USB-C powered IoT devkit in the M5Stack Nano series, built around the
+ESP32-H2. Unlike the Wi-Fi based NanoC6, the H2 variant has no Wi-Fi radio — it exposes an IEEE
+802.15.4 radio instead, for Zigbee, Thread and Matter-over-Thread use cases. The board also has an
+onboard RGB LED, a blue status LED, an IR transmitter, a user button, and a Grove port for
+expansion.
+
+## GPIO Pinout
+
+| Pin    | Function              |
+| ------ | --------------------- |
+| GPIO3  | IR transmitter        |
+| GPIO4  | Status LED (blue)     |
+| GPIO9  | Button                |
+| GPIO10 | RGB LED power enable  |
+| GPIO11 | RGB LED (WS2812) data |
+| GPIO1  | Grove port (yellow)   |
+| GPIO2  | Grove port (white)    |
+
+## Basic Configuration
+
+```yaml file=config.yaml
+```


### PR DESCRIPTION

# Brief description of the changes



## Type of changes

- [x] New device (a single device only — one device per pull request)
- [ ] Update existing device
- [ ] Removing a device
- [ ] General cleanup
- [ ] Other


## Checklist:

The rules below are enforced in CI by `npm run validate-devices` and `npm run validate-yaml`. The full reference is at [Configuration YAML files](https://devices.esphome.io/devices/adding-devices#configuration-yaml-files).

- [x] Adding a new device adds a single device only — one device per pull request.
- [x] Each example yaml lives in its own `.yaml` file alongside `index.md` and is pulled into the page with a fenced block of the form `` ```yaml file=<name>.yaml `` — no inline yaml on added or modified pages.
- [x] The first `file=` fence on the page references `config.yaml`.
- [x] `config.yaml` is **hardware-only**: no top-level `api:`, `ota:`, `mqtt:`, `web_server:`, `web_server_idf:`, `improv_serial:`, `captive_portal:`, `bluetooth_proxy:`, or `dashboard_import:`, and no `platform: homeassistant`, `platform: mqtt`, or `platform: template` anywhere in the tree.
- [ ] If `config.yaml` has a `wifi:` block, it contains only radio tunables (`country`, `power_save_mode`, `output_power`, …) — no `ssid`, `password`, `networks`, `manual_ip`, `eap`, or `use_address`. An empty `ap:` block is allowed.
- [ ] No passwords (literal **or** `!secret`) on `password:`, `*_password:`, or `psk:` keys, and no `!secret` references anywhere in any example yaml.
- [ ] For pages with `made-for-esphome: true` in frontmatter: at least one `` ```yaml url=… `` fence points at a `.yaml` file in the manufacturer's GitHub, Codeberg or GitLab repo (`github.com/<owner>/<repo>/(blob|raw)/<ref>/<path>.yaml`, the `raw.githubusercontent.com` equivalent, `codeberg.org/<owner>/<repo>/(src|raw)/(branch|tag|commit)/<ref>/<path>.yaml`, or `gitlab.com/<owner>/<repo>/-/(blob|raw)/<ref>/<path>.yaml`) so the rendered page shows the upstream config live.

<!-- DO NOT DELETE ANYTHING IN THIS TEMPLATE -->
